### PR TITLE
Implement XML deserialization (#2)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "1.0.0"
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Serde is a Julia library for (de)serializing data to/from various formats. The l
         <td>Deserialization</td>
         <td><div align=center>✓</div></td>
         <td><div align=center>✓</div></td>
-        <td><div align=center>(planned)</div></td>
+        <td><div align=center>✓</div></td>
         <td><div align=center>(planned)</div></td>
         <td><div align=center>✓</div></td>
         <td><div align=center>✓</div></td>
@@ -105,6 +105,20 @@ title,start_date,end_date
 julia> juliacon = deser_csv(JuliaCon, csv)
  1-element Vector{JuliaCon}:
   JuliaCon("JuliaCon 2024", Date("2024-07-09"), Date("2024-07-13"))
+
+# XML deserialization example
+xml = """
+<?xml version="1.0" encoding="UTF-8" ?>
+<root>
+	<title>JuliaCon 2024</title>
+	<start_date>2024-07-09</start_date>
+	<end_date>2024-07-13</end_date>
+</root>
+"""
+
+# Deserialize XML to a JuliaCon object
+julia> juliacon = deser_xml(JuliaCon, xml)
+ JuliaCon("JuliaCon 2024", Date("2024-07-09"), Date("2024-07-13"))
 ```
 
 If you want to see more deserialization options, then take a look at the corresponding [section](https://bhftbootcamp.github.io/Serde.jl/stable/pages/extended_de/) of the documentation

--- a/docs/src/pages/xml.md
+++ b/docs/src/pages/xml.md
@@ -1,5 +1,19 @@
 # XML
 
+## Parsing
+
+```@docs
+Serde.parse_xml
+Serde.XmlSyntaxError
+```
+
+## Deserialization
+
+```@docs
+Serde.deser_xml
+```
+
+
 ## Serialization
 
 ```@docs

--- a/src/De/De.jl
+++ b/src/De/De.jl
@@ -94,3 +94,6 @@ using .DeQuery
 
 include("DeCsv.jl")
 using .DeCsv
+
+include("DeXml.jl")
+using .DeXml

--- a/src/De/DeXml.jl
+++ b/src/De/DeXml.jl
@@ -1,0 +1,67 @@
+module DeXml
+
+export deser_xml
+
+using ..ParXml
+import ..to_deser
+
+"""
+    deser_xml(::Type{T}, x; kw...) -> T
+
+Creates a new object of type `T` and fill it with values from XML formated string `x` (or vector of UInt8).
+
+Keyword arguments `kw` is the same as in [`parse_xml`](@ref).
+
+## Examples
+```julia-repl
+julia> struct Person
+           attr::String
+           name::String
+           age::Int64
+       end
+
+julia> struct Content
+           person::Person
+           cars::Vector
+       end
+
+julia> struct Root
+           root::Content
+           version::String
+       end
+
+julia> xml = \"\"\"
+       <?xml version="1.0"?>
+       <root>
+       <person attr="human">
+           <name>John</name>
+           <age>30</age>
+       </person>
+       <cars>Audi</cars>
+       <cars>VW</cars>
+       <cars>Skoda</cars>
+       </root>
+       \"\"\";
+
+julia> deser_xml(Content, xml)
+Content(Person("human", "John", 30), Any["Audi", "VW", "Skoda"])
+
+Adding the ground key argument allows to get XML declaration.  An appropriate structure must be provided for correct deserialization procedure.
+
+julia> deser_xml(Root, xml; decl_struct=true)
+Root(Content(Person("human", "John", 30), Any["Audi", "VW", "Skoda"]), "1.0")
+```
+"""
+function deser_xml(::Type{T}, x; kw...) where {T}
+    return to_deser(T, parse_xml(x; kw...))
+end
+
+deser_xml(::Type{Nothing}, _) = nothing
+deser_xml(::Type{Missing}, _) = missing
+
+function deser_xml(f::Function, x; kw...)
+    object = parse_xml(x; kw...)
+    return to_deser(f(object), object)
+end
+
+end

--- a/src/Par/Par.jl
+++ b/src/Par/Par.jl
@@ -11,3 +11,6 @@ using .ParToml
 
 include("ParCsv.jl")
 using .ParCsv
+
+include("ParXml.jl")
+using .ParXml

--- a/src/Par/ParXml.jl
+++ b/src/Par/ParXml.jl
@@ -1,0 +1,156 @@
+module ParXml
+
+export XmlSyntaxError
+export parse_xml
+
+using EzXML
+
+"""
+    XmlSyntaxError <: Exception
+
+Exception thrown when a [`parse_xml`](@ref) fails due to incorrect XML syntax or any underlying error that occurs during parsing.
+
+## Fields
+- `message::String`: The error message.
+- `exception::Exception`: The catched exception.
+"""
+struct XmlSyntaxError <: Exception
+    message::String
+    exception::EzXML.XMLError
+end
+
+Base.show(io::IO, e::XmlSyntaxError) = print(io, e.message)
+
+function is_empty(node::EzXML.Node)
+    node_elem = nodecontent(node)
+    return isempty(node_elem) || all(isspace, node_elem)
+end
+
+is_text(node::EzXML.Node) = istext(node) || iscdata(node)
+
+has_text(node::EzXML.Node) = is_text(node) && !is_empty(node)
+
+function has_mixed_tags(nodes::EzXML.Node)
+    tags = []
+    for node_elem in eachelement(nodes)
+        tag = nodename(node_elem)
+        if isempty(tags) || tag != tags[end]
+            if tag in tags
+                return true
+            end
+            push!(tags, tag)
+        end
+    end
+    return false
+end
+
+function parse_doc(xml::EzXML.Document; decl_struct = false, kw...)
+    res = Dict{String,Any}()
+    res["version"] = version(xml)
+    try
+        res["encoding"] = encoding(xml)
+    catch
+    end
+    root_name = nodename(root(xml))
+    res[root_name] = parse_doc(root(xml); kw...)
+    return (decl_struct ? res : res[root_name])
+end
+
+function read_element(node::EzXML.Node, res::Dict{String,Any})
+    k = nodename(node)
+    v = parse_doc(node)
+
+    if haskey(res, "_")
+        push!(res["_"], Dict{String,Any}(k => v))
+    elseif haskey(res, k)
+        arr = isa(res[k], Array) ? res[k] : Any[res[k]]
+        push!(arr, v)
+        res[k] = arr
+    else
+        res[k] = v
+    end
+end
+
+function parse_doc(nodes::EzXML.Node; kw...)
+    res = Dict{String,Any}()
+
+    for attr in eachattribute(nodes)
+        res[nodename(attr)] = nodecontent(attr)
+    end
+
+    if any(has_text, eachnode(nodes)) || has_mixed_tags(nodes)
+        res["_"] = Any[]
+    end
+
+    for node in eachnode(nodes)
+        if iselement(node)
+            read_element(node, res)
+        elseif is_text(node) && haskey(res, "_") && strip(nodecontent(node)) != ""
+            push!(res["_"], strip(nodecontent(node)))
+        end
+    end
+
+    if haskey(res, "_")
+        v = res["_"]
+        if length(v) == 1 && isa(v[1], AbstractString)
+            res["_"] = v[1]
+            if length(res) == 1
+                res = res["_"]
+            end
+        end
+    end
+
+    return res
+end
+
+function parse_string(xml_string::AbstractString; kw...)
+    return parse_doc(parsexml(xml_string); kw...)
+end
+
+"""
+    parse_xml(x::AbstractString; kw...) -> Dict{String,Any}
+    parse_xml(x::Vector{UInt8}; kw...) -> Dict{String,Any}
+
+Parse a XML string `x` (or vector of UInt8) into a dictionary.
+
+## Keyword arguments
+- `decl_struct::Bool = false`: If false, only the contents of the root node are returned. If true, the declaration tags and the entire root node are returned.
+
+## Examples
+
+```julia-repl
+julia> xml = \"\"\"
+       <?xml version="1.0" encoding="UTF-8" ?>
+       <root>
+       <string>qwerty</string>
+       <vector>1</vector>
+       <vector>2</vector>
+       <vector>3</vector>
+       <dictionary>
+           <string>123</string>
+       </dictionary>
+       </root>
+       \"\"\";
+
+julia> parse_xml(xml)
+Dict{String, Any} with 3 entries:
+  "string"     => "qwerty"
+  "vector"     => Any["1", "2", "3"]
+  "dictionary" => Dict{String, Any}("string"=>"123")
+```
+"""
+function parse_xml end
+
+function parse_xml(x::S; kw...) where {S<:AbstractString}
+    try
+        parse_string(x; kw...)
+    catch e
+        throw(XmlSyntaxError("Invalid XML syntax", e))
+    end
+end
+
+function parse_xml(x::Vector{UInt8}; kw...)
+    return parse_xml(unsafe_string(pointer(x), length(x)); kw...)
+end
+
+end

--- a/src/Serde.jl
+++ b/src/Serde.jl
@@ -15,13 +15,15 @@ export to_json,
 export deser_json,
     deser_query,
     deser_toml,
-    deser_csv
+    deser_csv,
+    deser_xml
 
 # Par
 export parse_json,
     parse_query,
     parse_toml,
-    parse_csv
+    parse_csv,
+    parse_xml
 
 # Utl
 export @serde,

--- a/test/Par/Par.jl
+++ b/test/Par/Par.jl
@@ -2,3 +2,4 @@
 
 include("ParCsv.jl")
 include("ParQuery.jl")
+include("ParXml.jl")

--- a/test/Par/ParXml.jl
+++ b/test/Par/ParXml.jl
@@ -1,0 +1,181 @@
+# Par/ParXml
+
+@testset verbose = true "ParXml" begin
+    @testset "Case №1: Normal XML" begin
+        xml = """
+          <computers description="Office Computers">
+              <computer name="Dell" cpu="Intel" ram="16" storage="512" release_year="2020" has_ssd="true">
+                  <operating_systems type="Desktop">
+                      <os name="Windows" version="10"/>
+                      <os name="Ubuntu" version="20.04"/>
+                  </operating_systems>
+                  <ports>
+                      <port type="USB" version="3.0"/>
+                      <port type="HDMI" version="2.0"/>
+                  </ports>
+              </computer>
+              <computer name="Asus" cpu="AMD" ram="8" storage="256" release_year="2021" has_ssd="false">
+                  <operating_systems type="Gaming">
+                      <os name="Windows" version="11"/>
+                      <os name="Fedora" version="33"/>
+                  </operating_systems>
+                  <ports>
+                      <port type="USB" version="3.1"/>
+                      <port type="DisplayPort" version="1.4"/>
+                  </ports>
+              </computer>
+              <tag name="Dell">2000</tag>
+          </computers>
+        """
+        exp = Dict{String,Any}(
+            "tag" => Dict{String,Any}("name" => "Dell", "_" => "2000"),
+            "computer" => Dict{String,Any}[
+                Dict(
+                    "name" => "Dell",
+                    "operating_systems" => Dict{String,Any}(
+                        "type" => "Desktop",
+                        "os" => Dict{String,Any}[
+                            Dict("name" => "Windows", "version" => "10"),
+                            Dict("name" => "Ubuntu", "version" => "20.04"),
+                        ],
+                    ),
+                    "cpu" => "Intel",
+                    "ram" => "16",
+                    "storage" => "512",
+                    "has_ssd" => "true",
+                    "release_year" => "2020",
+                    "ports" => Dict{String,Any}(
+                        "port" => Dict{String,Any}[
+                            Dict("type" => "USB", "version" => "3.0"),
+                            Dict("type" => "HDMI", "version" => "2.0"),
+                        ],
+                    ),
+                ),
+                Dict(
+                    "name" => "Asus",
+                    "operating_systems" => Dict{String,Any}(
+                        "type" => "Gaming",
+                        "os" => Dict{String,Any}[
+                            Dict("name" => "Windows", "version" => "11"),
+                            Dict("name" => "Fedora", "version" => "33"),
+                        ],
+                    ),
+                    "cpu" => "AMD",
+                    "ram" => "8",
+                    "storage" => "256",
+                    "has_ssd" => "false",
+                    "release_year" => "2021",
+                    "ports" => Dict{String,Any}(
+                        "port" => Dict{String,Any}[
+                            Dict("type" => "USB", "version" => "3.1"),
+                            Dict("type" => "DisplayPort", "version" => "1.4"),
+                        ],
+                    ),
+                ),
+            ],
+            "description" => "Office Computers",
+        )
+        @test Serde.parse_xml(xml) == exp
+    end
+
+    @testset "Case №2: Array XML" begin
+        xml = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <root>
+          <level category="string">
+            <single>Single string</single>
+          </level>
+          <level category="array">
+            <string>there are</string>
+            <string>three identical</string>
+            <string>tags here</string>
+          </level>
+        </root>
+        """
+        exp = Dict{String,Any}(
+            "level" => Any[
+                Dict{String,Any}("category" => "string", "single" => "Single string"),
+                Dict{String,Any}(
+                    "string" => Any["there are", "three identical", "tags here"],
+                    "category" => "array",
+                ),
+            ],
+        )
+        @test Serde.parse_xml(xml) == exp
+    end
+
+    @testset "Case №3: Escape characters" begin
+        xml = """<valid>"'></valid>"""
+        exp = "\"'>"
+        @test Serde.parse_xml(xml) == exp
+
+        xml = """<valid attribute=">"/>"""
+        exp = Dict{String,Any}("attribute" => ">")
+        @test Serde.parse_xml(xml) == exp
+
+        xml = """<valid attribute="'"/>"""
+        exp = Dict{String,Any}("attribute" => "'")
+        @test Serde.parse_xml(xml) == exp
+
+        xml = """<valid attribute='"'/>"""
+        exp = Dict{String,Any}("attribute" => "\"")
+        @test Serde.parse_xml(xml) == exp
+
+        xml = """
+        <valid>
+          <!-- "'<>& comment -->
+        </valid>
+        """
+        exp = Dict{String,Any}()
+        @test Serde.parse_xml(xml) == exp
+
+        xml = "<valid><![CDATA[<sender>John Smith</sender>]]></valid>"
+        exp = "<sender>John Smith</sender>"
+        @test Serde.parse_xml(xml) == exp
+    end
+
+    @testset "Case №4: Exception testing" begin
+        xml = """
+        <wrong_order>
+          <?xml version="1.0" encoding="UTF-8"?>
+        </wrong_order>
+        """
+        @test_throws Serde.ParXml.XmlSyntaxError Serde.parse_xml(xml)
+
+        xml = """
+        <root>
+          <base>qwerty</base>
+          <unclosed_tag>
+        </root>
+        """
+        @test_throws Serde.ParXml.XmlSyntaxError Serde.parse_xml(xml)
+
+        xml = """
+        <wrong_order>
+          <tag>
+          </wrong_order>
+        </tag>
+        """
+        @test_throws Serde.ParXml.XmlSyntaxError Serde.parse_xml(xml)
+    end
+
+    @testset "Case №5: Parse with root level" begin
+        xml = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <root>
+          <first attr="attr_value">
+            <second>qwerty</second>
+          </first>
+        </root>
+        """
+        exp = Dict{String,Any}(
+            "root" => Dict{String,Any}(
+                "first" =>
+                    Dict{String,Any}("second" => "qwerty", "attr" => "attr_value"),
+            ),
+            "encoding" => "UTF-8",
+            "version" => "1.0",
+        )
+        @test Serde.parse_xml(xml; decl_struct = true) == exp
+    end
+end


### PR DESCRIPTION
I developed XML deserialization using the [EzXML.jl](https://github.com/JuliaIO/EzXML.jl) as a parser and some ideas from [XMLDict.jl](https://github.com/JuliaCloud/XMLDict.jl) as inspiration for implementing conversion to required dictionary by Deser. I also wrote a number of tests for parsing and escaping characters.

EzXML was chosen as the main library, since when benchmarked it showed identical speed to [LightXML](https://github.com/JuliaIO/LightXML.jl), but a smaller amount of allocated memory (and well, I liked its style).

I'm waiting for feedback, perhaps you have any suggestions for improving my implementation or other comments.

___
### Pull request checklist

- [ ] Did you bump the project version?
_Not yet_
- [x] Did you add a description to the Pull Request?
- [x] Did you add new tests?
- [x] Did you add reviewers?