### PR TITLE
Add docs for new case macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,35 @@
 # Serde.jl Changelog
 
-The latest version of this file can be found at the master branch of the [Serde.jl repository](https://bhftbootcamp.github.io/Serde.jl).
+The latest version of this file can be found at the master branch of the [Serde.jl](https://bhftbootcamp.github.io/Serde.jl) repository.
+
+## 3.0.0 (22/03/2024)
+
+### Added
+
+- Macro `@serde_pascal_case` to transform field names from PascalCase to snake_case for deserialization ([#26](../../pull/26)).
+- Macro `@serde_camel_case` to transform field names from camelCase to snake_case for deserialization ([#26](../../pull/26)).
+- Macro `@serde_kebab_case` to transform field names from kebab-case to snake_case for deserialization ([#26](../../pull/26)).
+- `Serde.ser_name` to override the default field name serialization ([#26](../../pull/26)).
+- `Serde.ser_value` to override the default value serialization ([#26](../../pull/26)).
+- `Serde.ser_type` to override the default type serialization ([#26](../../pull/26)).
+- `Serde.ser_ignore_field` to determine if a field should be ignored during serialization ([#26](../../pull/26)).
+
+### Changed
+
+- Renamed macro `@ser_json_name` to `@ser_name` for consistency with other serialization macros ([#26](../../pull/26)).
+- Renamed `ignore_null` to `ser_ignore_null` to align with serialization function naming conventions ([#26](../../pull/26)).
+- Renamed `ignore_field` to `ser_ignore_field` for clarity in serialization customization ([#26](../../pull/26)).
 
 ## 2.0.0 (22/02/2024)
 
 ### Added
 
-- Function `Serde.deser_xml` for deserializing XML (#14).
-- Function `Serde.parse_xml` for parsing XML (#14).
-- Function `Serde.to_yaml` for converting to YAML (#14).
-- Function `Serde.parse_yaml` for parsing YAML (#14).
-- Function `Serde.deser_yaml` for deserializing YAML (#14).
-- Parameter `with_names` to `to_csv` function to toggle inclusion of headers in CSV output (#17).
+- Function `Serde.deser_xml` for deserializing XML ([#14](../../pull/14)).
+- Function `Serde.parse_xml` for parsing XML ([#14](../../pull/14)).
+- Function `Serde.to_yaml` for converting to YAML ([#14](../../pull/14)).
+- Function `Serde.parse_yaml` for parsing YAML ([#14](../../pull/14)).
+- Function `Serde.deser_yaml` for deserializing YAML ([#14](../../pull/14)).
+- Parameter `with_names` in `to_csv` to toggle the inclusion or exclusion of headers in CSV output ([#17](../../pull/17)).
 
 ### Changed
 

--- a/docs/src/pages/utils.md
+++ b/docs/src/pages/utils.md
@@ -3,4 +3,7 @@
 ```@docs
 Serde.to_flatten
 Serde.@serde
+Serde.@serde_pascal_case
+Serde.@serde_camel_case
+Serde.@serde_kebab_case
 ```

--- a/src/Utl/Macros.jl
+++ b/src/Utl/Macros.jl
@@ -169,6 +169,28 @@ function to_pascal_case(field::String)::String
     return join(titlecase(w) for w in split(field, "_"))
 end
 
+"""
+    @serde_pascal_case T
+
+Marks all fields of type `T` with custom names corresponding to the Pascal case.
+
+!!! note
+    Initial field names must match the Snake case.
+
+See also [`Serde.custom_name`](@ref)
+
+## Examples
+```julia-repl
+julia> struct MySnakes
+           red_snake::Int64
+       end
+
+julia> @serde_pascal_case MySnakes
+
+julia> Serde.deser(MySnakes, Dict("RedSnake" => 1))
+MySnakes(1)
+```
+"""
 macro serde_pascal_case(T)
     return serde_custom_names(T, field -> Symbol(to_pascal_case(string(field))))
 end
@@ -177,6 +199,28 @@ function to_camel_case(field::String)::String
     return split(field, "_")[1] * join(titlecase(w) for w in split(field, "_")[2:end])
 end
 
+"""
+   @serde_camel_case T
+
+Marks all fields of type `T` with custom names corresponding to the Camel case.
+
+!!! note
+    Initial field names must match the Snake case.
+
+See also [`Serde.custom_name`](@ref)
+
+## Examples
+```julia-repl
+julia> struct MySnakes
+           forest_snake::Int64
+       end
+
+julia> @serde_camel_case MySnakes
+
+julia> Serde.deser(MySnakes, Dict("forestSnake" => 2))
+MySnakes(2)
+```
+"""
 macro serde_camel_case(T)
     return serde_custom_names(T, field -> Symbol(to_camel_case(string(field))))
 end
@@ -185,6 +229,28 @@ function to_kebab_case(field::String)::String
     return join([lowercase(w) for w in split(field, "_")], "-")
 end
 
+"""
+    @serde_kebab_case T
+
+Marks all fields of type `T` with custom names corresponding to the Kebab case.
+
+!!! note
+    Initial field names must match the Snake case.
+
+See also [`Serde.custom_name`](@ref)
+
+## Examples
+```julia-repl
+julia> struct MySnakes
+           pretty_snake::Int64
+       end
+
+julia> @serde_kebab_case MySnakes
+
+julia> Serde.deser(MySnakes, Dict("pretty-snake" => 3))
+MySnakes(3)
+```
+"""
 macro serde_kebab_case(T)
     return serde_custom_names(T, field -> Symbol(to_kebab_case(string(field))))
 end

--- a/src/Utl/Macros.jl
+++ b/src/Utl/Macros.jl
@@ -172,10 +172,10 @@ end
 """
     @serde_pascal_case T
 
-Marks all fields of type `T` with custom names corresponding to the Pascal case.
+Marks all fields of type `T` with custom names corresponding to Pascal case.
 
 !!! note
-    Initial field names must match the Snake case.
+    Field names of type `T` must match Snake case.
 
 See also [`Serde.custom_name`](@ref)
 
@@ -202,10 +202,10 @@ end
 """
    @serde_camel_case T
 
-Marks all fields of type `T` with custom names corresponding to the Camel case.
+Marks all fields of type `T` with custom names corresponding to Camel case.
 
 !!! note
-    Initial field names must match the Snake case.
+    Field names of type `T` must match Snake case.
 
 See also [`Serde.custom_name`](@ref)
 
@@ -232,10 +232,10 @@ end
 """
     @serde_kebab_case T
 
-Marks all fields of type `T` with custom names corresponding to the Kebab case.
+Marks all fields of type `T` with custom names corresponding to Kebab case.
 
 !!! note
-    Initial field names must match the Snake case.
+    Field names of type `T` must match Snake case.
 
 See also [`Serde.custom_name`](@ref)
 

--- a/src/Utl/Macros.jl
+++ b/src/Utl/Macros.jl
@@ -200,7 +200,7 @@ function to_camel_case(field::String)::String
 end
 
 """
-   @serde_camel_case T
+    @serde_camel_case T
 
 Marks all fields of type `T` with custom names corresponding to `camelCase`.
 

--- a/src/Utl/Macros.jl
+++ b/src/Utl/Macros.jl
@@ -172,10 +172,10 @@ end
 """
     @serde_pascal_case T
 
-Marks all fields of type `T` with custom names corresponding to Pascal case.
+Marks all fields of type `T` with custom names corresponding to `PascalCase`.
 
 !!! note
-    Field names of type `T` must match Snake case.
+    Field names of type `T` must match `snake_case`.
 
 See also [`Serde.custom_name`](@ref)
 
@@ -202,10 +202,10 @@ end
 """
    @serde_camel_case T
 
-Marks all fields of type `T` with custom names corresponding to Camel case.
+Marks all fields of type `T` with custom names corresponding to `camelCase`.
 
 !!! note
-    Field names of type `T` must match Snake case.
+    Field names of type `T` must match `snake_case`.
 
 See also [`Serde.custom_name`](@ref)
 
@@ -232,10 +232,10 @@ end
 """
     @serde_kebab_case T
 
-Marks all fields of type `T` with custom names corresponding to Kebab case.
+Marks all fields of type `T` with custom names corresponding to `kebab-case`.
 
 !!! note
-    Field names of type `T` must match Snake case.
+    Field names of type `T` must match `snake_case`.
 
 See also [`Serde.custom_name`](@ref)
 


### PR DESCRIPTION
### Pull request checklist

- [ ] Did you bump the project version?
- [x] Did you add a description to the Pull Request?
- [x] Did you add new tests?
- [x] Did you add reviewers?

## 3.0.0 (22/03/2024)

### Added

- Macro `@serde_pascal_case` to transform field names from PascalCase to snake_case for deserialization ([#26](../../pull/26)).
- Macro `@serde_camel_case` to transform field names from camelCase to snake_case for deserialization ([#26](../../pull/26)).
- Macro `@serde_kebab_case` to transform field names from kebab-case to snake_case for deserialization ([#26](../../pull/26)).
- `Serde.ser_name` to override the default field name serialization ([#26](../../pull/26)).
- `Serde.ser_value` to override the default value serialization ([#26](../../pull/26)).
- `Serde.ser_type` to override the default type serialization ([#26](../../pull/26)).
- `Serde.ser_ignore_field` to determine if a field should be ignored during serialization ([#26](../../pull/26)).

### Changed

- Renamed macro `@ser_json_name` to `@ser_name` for consistency with other serialization macros ([#26](../../pull/26)).
- Renamed `ignore_null` to `ser_ignore_null` to align with serialization function naming conventions ([#26](../../pull/26)).
- Renamed `ignore_field` to `ser_ignore_field` for clarity in serialization customization ([#26](../../pull/26)).

