### PR TITLE
Switch to YYJSON 

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,6 @@ julia> to_yaml(juliacon) |> print
 title: "JuliaCon 2024"
 start_date: "2024-07-09"
 end_date: "2024-07-13"
-
 ```
 
 If you want to see more serialization options, then take a look at the corresponding [section](https://bhftbootcamp.github.io/Serde.jl/stable/pages/extended_ser/) of the documentation

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -32,7 +32,6 @@ Serde is a Julia library for (de)serializing data to/from various formats. The l
     </table>
   </body>
 </html>
-```
 
 ## Installation
 
@@ -189,7 +188,6 @@ julia> to_yaml(juliacon) |> print
 title: "JuliaCon 2024"
 start_date: "2024-07-09"
 end_date: "2024-07-13"
-
 ```
 
 If you want to see more serialization options, then take a look at the corresponding [section](https://bhftbootcamp.github.io/Serde.jl/stable/pages/extended_ser/) of the documentation

--- a/docs/src/pages/extended_ser.md
+++ b/docs/src/pages/extended_ser.md
@@ -151,7 +151,7 @@ julia> to_json(Computer("i7-12900", "rtx-4090")) |> print
 ## Ignoring fields
 
 Finally, we can specify what fields must be ignored.
-In this case, you just need to extend the `Serde.<SubModule>.ignore_field` function.
+In this case, you just need to extend the `Serde.<SubModule>.ser_ignore_field` function.
 This approach is supported by the following serialization methods:
 
 - [`to_json`](@ref) (`SerJson` submodule).
@@ -160,7 +160,7 @@ The return value of your method must be of type `Bool`.
 The default signature is:
 
 ```julia
-ignore_field(::Type{T}, ::Val{x})::Bool where {T,x} = false
+ser_ignore_field(::Type{T}, ::Val{x})::Bool where {T,x} = false
 ```
 
 ### Example
@@ -181,10 +181,10 @@ struct Box
 end
 ```
 
-Let's add the `SerJson.ignore_field` method for type `Box`.
+Let's add the `SerJson.ser_ignore_field` method for type `Box`.
 
 ```julia
-SerJson.ignore_field(::Type{Box}, ::Val{:length}) = true
+SerJson.ser_ignore_field(::Type{Box}, ::Val{:length}) = true
 ```
 
 Because the field `length` is ignorable, the resulting JSON string contains only `height` and `width` values.

--- a/src/De/De.jl
+++ b/src/De/De.jl
@@ -30,10 +30,17 @@ struct WrongType <: DeserError
 end
 
 function Base.show(io::IO, e::WrongType)
-    return print(
-        io,
-        "WrongType: for '$(e.maintype)' value '$(e.value)' has wrong type '$(e.key)::$(e.from_type)', must be '$(e.key)::$(e.to_type)'",
-    )
+    return if e.value == "Ptr{YYJSONVal}"
+            print(
+                io,
+                "WrongType: for '$(e.maintype)' got wrong type '$(e.key)::$(e.from_type)', must be '$(e.key)::$(e.to_type)'",
+            )
+        else
+            print(
+                io,
+                "WrongType: for '$(e.maintype)' value '$(e.value)' has wrong type '$(e.key)::$(e.from_type)', must be '$(e.key)::$(e.to_type)'",
+            )
+        end
 end
 
 include("Deser.jl")

--- a/src/De/DeJson.jl
+++ b/src/De/DeJson.jl
@@ -150,7 +150,7 @@ function deser(::DictType, ::Type{T}, value_ptr::Ptr{YYJSONVal}) where {K,V,T<:A
         GC.@preserve iter begin
             yyjson_obj_iter_init(value_ptr, iter_ptr) || throw(YYJSONError("Failed to initialize object iterator."))
             dict_elements = T()
-            for i in 1:yyjson_obj_size(value_ptr)
+            for _ = 1:yyjson_obj_size(value_ptr)
                 key_ptr = yyjson_obj_iter_next(iter_ptr)
                 value_ptr = yyjson_obj_iter_get_val(key_ptr)
                 dict_elements[deser(K, key_ptr)] = deser(V, value_ptr)
@@ -264,7 +264,6 @@ function deser_obj(::CustomType, ::Type{T}, obj_ptr::Ptr{YYJSONVal}) where {T}
         else
             eldeser(T, field_type, key, value_ptr)
         end
-
         field_values[index] = if isnothing(value) || ismissing(value) || isempty(T, value)
             nulltype(field_type)
         else

--- a/src/De/DeJson.jl
+++ b/src/De/DeJson.jl
@@ -358,7 +358,7 @@ function read_json_doc(json; kw...)
     err = YYJSONReadErr()
     doc_ptr = yyjson_read_opts(
         json,
-        length(json),
+        ncodeunits(json),
         bitwise_read_flag(; kw...),
         C_NULL,
         pointer_from_objref(err),
@@ -392,13 +392,17 @@ julia> deser_json(Data, json)
 Data(100, "json", Record(100.0))
 ```
 """
-function deser_json(::Type{T}, x; kw...) where {T}
+function deser_json(::Type{T}, x::AbstractString; kw...) where {T}
     doc_ptr = read_json_doc(x; kw...)
     try
         return deser(T, yyjson_doc_get_root(doc_ptr))
     finally
         yyjson_doc_free(doc_ptr)
     end
+end
+
+function deser_json(::Type{T}, json::AbstractVector{UInt8}; kw...) where {T}
+    return deser_json(T, unsafe_string(pointer(json), length(json)); kw...)
 end
 
 deser_json(::Type{Nothing}, _) = nothing

--- a/src/De/DeJson.jl
+++ b/src/De/DeJson.jl
@@ -36,16 +36,6 @@ function deser(::Type{T}, ::Type{Nothing}, val_ptr::Ptr{YYJSONVal}) where {T}
     return deser(Nothing, val_ptr)
 end
 
-# NOTE: Highly decrease performance but allows to define custom deser(...) behavior
-# function deser(::Type{T}, ::Type{E}, val_ptr::Ptr{YYJSONVal}) where {T,E}
-#     mod = parentmodule(deser, (Type{T},Type{E},Any))
-#     return if !(mod == Serde || mod == DeJson)
-#         deser(T, E, deser(Any, val_ptr))
-#     else
-#         deser(E, val_ptr)
-#     end
-# end
-
 function deser(::Type{T}, ::Type{E}, val_ptr::Ptr{YYJSONVal}) where {T,E}
     return deser(E, val_ptr)
 end

--- a/src/De/DeJson.jl
+++ b/src/De/DeJson.jl
@@ -52,7 +52,7 @@ function deser(::PrimitiveType, ::Type{T}, value_ptr::Ptr{YYJSONVal}) where {T<:
     elseif yyjson_is_null(value_ptr)
         nothing
     else
-        throw(error("Expected a string for type `AbstractString`."))
+        error("Expected a string for type `AbstractString`.")
     end
 end
 
@@ -64,7 +64,7 @@ function deser(::PrimitiveType, ::Type{T}, value_ptr::Ptr{YYJSONVal}) where {T<:
     elseif yyjson_is_null(value_ptr)
         nothing
     else
-        throw(error("Expected a number for type `Number`."))
+        error("Expected a number for type `Number`.")
     end
 end
 
@@ -83,6 +83,8 @@ function deser(h::PrimitiveType, ::Type{T}, value_ptr::Ptr{YYJSONVal}) where {T<
         T(Int64(yyjson_get_num(value_ptr)))
     elseif yyjson_is_bool(value_ptr)
         T(Int64(yyjson_get_bool(value_ptr)))
+    else
+        error("Expected a string or number for type `Enum`.")
     end
 end
 
@@ -94,7 +96,7 @@ function deser(::PrimitiveType, ::Type{T}, value_ptr::Ptr{YYJSONVal}) where {T<:
     elseif yyjson_is_null(value_ptr)
         nothing
     else
-        throw(error("Expected a string for type `Symbol`."))
+        error("Expected a string for type `Symbol`.")
     end
 end
 
@@ -104,7 +106,7 @@ function deser(::NullType, ::Type{Nothing}, value_ptr::Ptr{YYJSONVal})
     return if yyjson_is_null(value_ptr)
         nothing
     else
-        throw(error("Expected null for type `Nothing`."))
+        error("Expected a null for type `Nothing`.")
     end
 end
 
@@ -112,19 +114,23 @@ function deser(::NullType, ::Type{Missing}, value_ptr::Ptr{YYJSONVal})
     return if yyjson_is_null(value_ptr)
         missing
     else
-        throw(error("Expected null for type `Missing`."))
+        error("Expected a null for type `Missing`.")
     end
 end
 
 function deser(::NullType, ::Type{Union{Nothing,T}}, value_ptr::Ptr{YYJSONVal}) where {T}
     return if yyjson_is_null(value_ptr)
         deser(T, value_ptr)
+    else
+        error("Expected a null for type `Nothing`.")
     end
 end
 
 function deser(::NullType, ::Type{Union{Missing,T}}, value_ptr::Ptr{YYJSONVal}) where {T}
     return if yyjson_is_null(value_ptr)
         deser(T, value_ptr)
+    else
+        error("Expected a null for type `Missing`.")
     end
 end
 
@@ -133,6 +139,8 @@ end
 function deser(::NTupleType, ::Type{T}, value_ptr::Ptr{YYJSONVal}) where {T<:NamedTuple}
     return if yyjson_is_obj(value_ptr)
         (; deser(Dict{Symbol,Any}, value_ptr)...)
+    else
+        error("Expected an object for type `NamedTuple`.")
     end
 end
 
@@ -141,6 +149,8 @@ end
 function deser(::DictType, ::Type{T}, value_ptr::Ptr{YYJSONVal}) where {N,T<:AbstractSet{N}}
     return if yyjson_is_arr(value_ptr)
         T(deser(Vector{N}, value_ptr))
+    else
+        error("Expected an array for type `AbstractSet`.")
     end
 end
 
@@ -159,6 +169,8 @@ function deser(::DictType, ::Type{T}, value_ptr::Ptr{YYJSONVal}) where {K,V,T<:A
             end
         end
         dict_elements
+    else
+        error("Expected an object for type `AbstractDict`.")
     end
 end
 
@@ -178,6 +190,8 @@ function deser(::ArrayType, ::Type{T}, value_ptr::Ptr{YYJSONVal}) where {T<:Abst
             end
         end
         array_elements
+    else
+        error("Expected an array for type `AbstractVector`.")
     end
 end
 
@@ -199,6 +213,8 @@ function deser(::ArrayType, ::Type{T}, value_ptr::Ptr{YYJSONVal}) where {T<:Tupl
             end
             T(tuple_elements)
         end
+    else
+        error("Expected an array for type `Tuple`.")
     end
 end
 
@@ -220,22 +236,22 @@ function deser_arr(::CustomType, ::Type{T}, value_ptr::Ptr{YYJSONVal}) where {T}
     end
 end
 
-function typeof_yyjson_val(val_ptr::Ptr{YYJSONVal})
-    return if yyjson_is_str(val_ptr)
+function typeof_yyjson_val(value_ptr::Ptr{YYJSONVal})
+    return if yyjson_is_str(value_ptr)
         String
-    elseif yyjson_is_raw(val_ptr)
+    elseif yyjson_is_raw(value_ptr)
         String
-    elseif yyjson_is_real(val_ptr)
+    elseif yyjson_is_real(value_ptr)
         Float64
-    elseif yyjson_is_int(val_ptr)
+    elseif yyjson_is_int(value_ptr)
         Int
-    elseif yyjson_is_bool(val_ptr)
+    elseif yyjson_is_bool(value_ptr)
         Bool
-    elseif yyjson_is_obj(val_ptr)
+    elseif yyjson_is_obj(value_ptr)
         Dict{String,Any}
-    elseif yyjson_is_arr(val_ptr)
+    elseif yyjson_is_arr(value_ptr)
         Vector{Any}
-    elseif yyjson_is_null(val_ptr)
+    elseif yyjson_is_null(value_ptr)
         Nothing
     else
         Any
@@ -309,6 +325,8 @@ function deser(type::CustomType, ::Type{T}, value_ptr::Ptr{YYJSONVal}) where {T}
         deser_arr(type, T, value_ptr)
     elseif yyjson_is_obj(value_ptr)
         deser_obj(type, T, value_ptr)
+    else
+        error("Expected an array or object.")
     end
 end
 

--- a/src/De/DeJson.jl
+++ b/src/De/DeJson.jl
@@ -227,7 +227,7 @@ function deser_arr(::CustomType, ::Type{T}, val_ptr::Ptr{YYJSONVal}) where {T}
 end
 
 function eldeser(::Type{T}, ::Type{E}, key::Union{AbstractString,Symbol}, val_ptr::Ptr{YYJSONVal}) where {T,E}
-    E isa Union && E.a isa Nothing && eldeser(T, E.b, key, val_ptr)
+    E isa Union && E.a == Nothing && return eldeser(T, E.b, key, val_ptr)
     return try
         if yyjson_is_str(val_ptr) && <:(E, AbstractString)
             unsafe_string(yyjson_get_str(val_ptr))
@@ -242,8 +242,8 @@ function eldeser(::Type{T}, ::Type{E}, key::Union{AbstractString,Symbol}, val_pt
         elseif yyjson_is_obj(val_ptr) && <:(E, AbstractDict)
             deser(E, val_ptr)
         elseif yyjson_is_arr(val_ptr) && <:(E, AbstractVector)
-            deser(E, val_ptr) 
-        else 
+            deser(E, val_ptr)
+        else
             deser(T, E, deser(Any, val_ptr))
         end
     catch e

--- a/src/De/DeJson.jl
+++ b/src/De/DeJson.jl
@@ -372,8 +372,10 @@ function deser_json(::Type{T}, json::AbstractVector{UInt8}; kw...) where {T}
     return deser_json(T, unsafe_string(pointer(json), length(json)); kw...)
 end
 
-deser_json(::Type{Nothing}, _) = nothing
-deser_json(::Type{Missing}, _) = missing
+deser_json(::Type{Nothing}, ::AbstractVector{UInt8}) = nothing
+deser_json(::Type{Nothing}, ::AbstractString) = nothing
+deser_json(::Type{Missing}, ::AbstractVector{UInt8}) = missing
+deser_json(::Type{Missing}, ::AbstractString) = missing
 
 function deser_json(f::Function, x; kw...)
     object = Serde.parse_json(x; kw...)

--- a/src/De/Deser.jl
+++ b/src/De/Deser.jl
@@ -161,6 +161,7 @@ function deser(::Type{StructType}, ::Type{Nothing}, data::D) where {StructType<:
 end
 
 function deser(::Type{T}, data::D) where {T<:Any,D<:Any}
+    #println("T = $T and ClassType(T) = $(ClassType(T))")
     return deser(ClassType(T), T, data)
 end
 

--- a/src/De/Deser.jl
+++ b/src/De/Deser.jl
@@ -161,7 +161,6 @@ function deser(::Type{StructType}, ::Type{Nothing}, data::D) where {StructType<:
 end
 
 function deser(::Type{T}, data::D) where {T<:Any,D<:Any}
-    #println("T = $T and ClassType(T) = $(ClassType(T))")
     return deser(ClassType(T), T, data)
 end
 

--- a/src/De/Deser.jl
+++ b/src/De/Deser.jl
@@ -201,12 +201,7 @@ end
 # to Enum
 
 function deser(h::PrimitiveType, ::Type{T}, data::D)::T where {T<:Enum,D<:AbstractString}
-    n = tryparse(Int64, data)
-    if isnothing(n)
-        deser(h, T, Symbol(data))
-    else
-        deser(h, T, n)
-    end
+    deser(h, T, Symbol(data))
 end
 
 function deser(::PrimitiveType, ::Type{T}, data::D)::T where {T<:Enum,D<:Integer}

--- a/src/De/Deser.jl
+++ b/src/De/Deser.jl
@@ -484,6 +484,8 @@ Computer("N/A", "N/A")
 """
 (nulltype(::Type{T})::Nothing) where {T<:Any} = nothing
 
+(nulltype(::Type{Missing})) = missing
+
 (nulltype(::Type{Union{Nothing,T}})::Nothing) where {T<:Any} = nothing
 
 (nulltype(::Type{Union{Missing,T}})::Missing) where {T<:Any} = missing

--- a/test/deser.jl
+++ b/test/deser.jl
@@ -759,4 +759,35 @@ using Test, Dates
         exp_obj2 = MyType(SubType("test2"))
         @test deser_json(MyType, json_str2) == exp_obj2
     end
+
+    @testset "Case №41: Deserialization Vector to Struct" begin
+        struct Point
+            x::Int
+            y::Int
+        end
+        struct Line
+            a::Point
+            b::Point
+        end
+        struct Arrow
+            label::String
+            segments::Vector{Line}
+            dashed::Bool
+        end
+        json_str = """{
+            "label": "Hello",
+            "segments": [
+                 {"a": {"x": 1, "y": 1}, "b": {"x": 2, "y": 2}},
+                 {"a": {"x": 2, "y": 2}, "b": {"x": 3, "y": 3}}
+             ],
+             "dashed": false
+        }"""
+
+        exp_obj = Arrow("Hello", Line[Line(Point(1, 1), Point(2, 2)), Line(Point(2, 2), Point(3, 3))], false)
+        calc_obj = deser_json(Arrow, json_str)
+        calc_obj.label == exp_obj.label
+        calc_obj.segments[1] == exp_obj.segments[1]
+        calc_obj.segments[2] == exp_obj.segments[2]
+        calc_obj.dashed == exp_obj.dashed
+    end
 end

--- a/test/deser.jl
+++ b/test/deser.jl
@@ -838,4 +838,16 @@ using Test, Dates
         exp_obj2 = UnionType("100")
         @test deser_json(UnionType, exp_str2) == exp_obj2
     end
+
+    @testset "Case №44: Deserialization to from String and Vector{UInt8}" begin
+        struct MyType44
+            value1::Float64
+            value2::String
+        end
+
+        exp_str = "{\"value1\":100.0, \"value2\": \"100\"}"
+        exp_obj = MyType44(100.0, "100")
+        @test deser_json(MyType44, exp_str) == exp_obj
+        @test deser_json(MyType44, collect(codeunits(exp_str))) == exp_obj
+    end
 end

--- a/test/deser.jl
+++ b/test/deser.jl
@@ -659,7 +659,7 @@ using Test, Dates
         end
 
         exp_str = """ {"correlation_id":2,"method":"subscribe.status","payload":{}} """
-        @test_throws "WrongType: for 'Message{Nothing}' value 'Ptr{YYJSONVal}' has wrong type 'payload::Dict{String, Any}', must be 'payload::Nothing'" Serde.deser_json(
+        @test_throws "WrongType: for 'Message{Nothing}' got wrong type 'payload::Dict{String, Any}', must be 'payload::Nothing'" Serde.deser_json(
             Message{Nothing},
             exp_str,
         )

--- a/test/deser.jl
+++ b/test/deser.jl
@@ -800,10 +800,10 @@ using Test, Dates
 
         exp_obj = Arrow("Hello", Line[Line(Point(1, 1), Point(2, 2)), Line(Point(2, 2), Point(3, 3))], false)
         calc_obj = deser_json(Arrow, json_str)
-        calc_obj.label == exp_obj.label
-        calc_obj.segments[1] == exp_obj.segments[1]
-        calc_obj.segments[2] == exp_obj.segments[2]
-        calc_obj.dashed == exp_obj.dashed
+        @test calc_obj.label == exp_obj.label
+        @test calc_obj.segments[1] == exp_obj.segments[1]
+        @test calc_obj.segments[2] == exp_obj.segments[2]
+        @test calc_obj.dashed == exp_obj.dashed
     end
 
     @testset "Case №42: Deserialization Inf" begin
@@ -823,5 +823,19 @@ using Test, Dates
 
         exp_obj = JsonBar3(true, 101.101, nothing, Inf, missing, nothing)
         @test deser_json(JsonBar3, exp_str2) == exp_obj
+    end
+
+    @testset "Case №43: Deserialization to Union" begin
+        struct UnionType
+            union_value::Union{Float64, String}
+        end
+
+        exp_str1 = "{\"union_value\":100.0}"
+        exp_obj1 = UnionType(100.0)
+        @test deser_json(UnionType, exp_str1) == exp_obj1
+
+        exp_str2 = "{\"union_value\":\"100\"}"
+        exp_obj2 = UnionType("100")
+        @test deser_json(UnionType, exp_str2) == exp_obj2
     end
 end

--- a/test/deser.jl
+++ b/test/deser.jl
@@ -659,7 +659,7 @@ using Test, Dates
         end
 
         exp_str = """ {"correlation_id":2,"method":"subscribe.status","payload":{}} """
-        @test_throws "WrongType: for 'Message{Nothing}' value 'Dict{String, Any}()' has wrong type 'payload::Dict{String, Any}', must be 'payload::Nothing'" Serde.deser_json(
+        @test_throws "WrongType: for 'Message{Nothing}' value 'Ptr{YYJSONVal}' has wrong type 'payload::Dict{String, Any}', must be 'payload::Nothing'" Serde.deser_json(
             Message{Nothing},
             exp_str,
         )
@@ -722,6 +722,21 @@ using Test, Dates
         @test Serde.deser(Tuples, exp_kvs).a == exp_obj.a
         @test Serde.deser(Tuples, exp_kvs).b == exp_obj.b
         @test Serde.deser(Tuples, exp_kvs).c == exp_obj.c
+
+        exp_str2 = """
+        [
+            ["1", "2", "3"],
+            ["1", "2"],
+            ["a", "b", "c"],
+            ["s", "1"],
+            ["0.01", "1"]
+        ]
+        """
+        @test Serde.deser_json(DifferentTuples, exp_str2).a == Tuple(("1", "2", "3"))
+        @test Serde.deser_json(DifferentTuples, exp_str2).b == NTuple{2}(("1", "2"))
+        @test Serde.deser_json(DifferentTuples, exp_str2).c == Tuple{String,String,String}(("a", "b", "c"))
+        @test Serde.deser_json(DifferentTuples, exp_str2).d == Tuple{String,Int64}(("s", 1))
+        @test Serde.deser_json(DifferentTuples, exp_str2).e == Tuple{Float64,Int64}((0.01, 1))
     end
 
     @testset "Case №40: Custom deserialization" begin

--- a/test/deser.jl
+++ b/test/deser.jl
@@ -839,7 +839,7 @@ using Test, Dates
         @test deser_json(UnionType, exp_str2) == exp_obj2
     end
 
-    @testset "Case №44: Deserialization to from String and Vector{UInt8}" begin
+    @testset "Case №44: Deserialization from String and Vector{UInt8}" begin
         struct MyType44
             value1::Float64
             value2::String
@@ -849,5 +849,12 @@ using Test, Dates
         exp_obj = MyType44(100.0, "100")
         @test deser_json(MyType44, exp_str) == exp_obj
         @test deser_json(MyType44, collect(codeunits(exp_str))) == exp_obj
+    end
+
+    @testset "Case №45: Deserialization to Nothing, Missing" begin
+        @test isnothing(deser_json(Nothing, UInt8[]))
+        @test isnothing(deser_json(Nothing, ""))
+        @test ismissing(deser_json(Missing, UInt8[]))
+        @test ismissing(deser_json(Missing, ""))
     end
 end

--- a/test/deser.jl
+++ b/test/deser.jl
@@ -723,4 +723,40 @@ using Test, Dates
         @test Serde.deser(Tuples, exp_kvs).b == exp_obj.b
         @test Serde.deser(Tuples, exp_kvs).c == exp_obj.c
     end
+
+    @testset "Case №40: Custom deserialization" begin
+        struct SubType
+            y::String
+        end
+        struct MyType
+            x::SubType
+        end
+        json_str = """
+            {
+                "x":{
+                    "y":{
+                        "z":[1, 2, 3]
+                    }
+                }
+            }
+        """
+        function Serde.deser(::Type{<:SubType}, ::Type{String}, x::AbstractDict)
+            return "test"
+        end
+        exp_obj = MyType(SubType("test"))
+        @test deser_json(MyType, json_str) == exp_obj
+
+        json_str2 = """
+            {
+                "x":{
+                    "y":[1, 2, 3]
+                }
+            }
+        """
+        function Serde.deser(::Type{<:SubType}, ::Type{String}, x::AbstractVector)
+            return "test2"
+        end
+        exp_obj2 = MyType(SubType("test2"))
+        @test deser_json(MyType, json_str2) == exp_obj2
+    end
 end

--- a/test/deser.jl
+++ b/test/deser.jl
@@ -790,4 +790,23 @@ using Test, Dates
         calc_obj.segments[2] == exp_obj.segments[2]
         calc_obj.dashed == exp_obj.dashed
     end
+
+    @testset "Case №42: Deserialization Inf" begin
+        exp_str1 = """{"bool":true,"number":101.101,"nan":null,"inf":null,"_missing":null,"_nothing":null}"""
+        struct JsonBar3
+            bool::Bool
+            number::Float64
+            nan::Nothing
+            inf::Float64
+            _missing::Missing
+            _nothing::Nothing
+        end
+
+        @test_throws "ParamError: parameter 'inf::Float64' was not passed or has the value 'nothing'" deser_json(JsonBar3, exp_str1)
+
+        exp_str2 = """{"bool":true,"number":101.101,"nan":null,"inf":"Inf","_missing":null,"_nothing":null}"""
+
+        exp_obj = JsonBar3(true, 101.101, nothing, Inf, missing, nothing)
+        @test deser_json(JsonBar3, exp_str2) == exp_obj
+    end
 end


### PR DESCRIPTION
### Pull request checklist

- [x] Did you bump the project version?
- [x] Did you add a description to the Pull Request?
- [x] Did you add new tests?
- [x] Did you add reviewers?

### Old deser
```
@benchmark deser_json(ExchangeInfoData, json_str)
BenchmarkTools.Trial: 7 samples with 1 evaluation.
 Range (min … max):  788.652 ms … 850.092 ms  ┊ GC (min … max): 27.89% … 31.28%
 Time  (median):     820.066 ms               ┊ GC (median):    30.80%
 Time  (mean ± σ):   822.370 ms ±  20.313 ms  ┊ GC (mean ± σ):  30.34% ±  1.43%

  █                  █         █ █            █   █           █  
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁█▁█▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁█▁▁▁▁▁▁▁▁▁▁▁█ ▁
  789 ms           Histogram: frequency by time          850 ms <

 Memory estimate: 667.81 MiB, allocs estimate: 4027315.
```

### New deser
```
@benchmark deser_json(ExchangeInfoData, json_str)
BenchmarkTools.Trial: 18 samples with 1 evaluation.
 Range (min … max):  276.343 ms … 308.855 ms  ┊ GC (min … max): 0.00% … 2.33%
 Time  (median):     288.023 ms               ┊ GC (median):    1.47%
 Time  (mean ± σ):   289.823 ms ±   9.065 ms  ┊ GC (mean ± σ):  1.39% ± 1.41%

  ▁    ▁ ▁ ▁    █▁▁  ▁    █     ▁▁         ▁  ▁ ▁▁            ▁  
  █▁▁▁▁█▁█▁█▁▁▁▁███▁▁█▁▁▁▁█▁▁▁▁▁██▁▁▁▁▁▁▁▁▁█▁▁█▁██▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  276 ms           Histogram: frequency by time          309 ms <

 Memory estimate: 31.92 MiB, allocs estimate: 394033.
```

```
julia> versioninfo()
Julia Version 1.11.1
Commit 8f5b7ca12ad (2024-10-16 10:53 UTC)
Build Info:
  Official https://julialang.org/ release
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 20 × 12th Gen Intel(R) Core(TM) i7-12700H
  WORD_SIZE: 64
  LLVM: libLLVM-16.0.6 (ORCJIT, alderlake)
Threads: 1 default, 0 interactive, 1 GC (on 20 virtual cores)
```

