### PR TITLE
Optimization of `to_csv`

### DIFF
--- a/src/Ser/SerCsv.jl
+++ b/src/Ser/SerCsv.jl
@@ -26,7 +26,7 @@ Uses `data` element values to make csv rows with dictionary key-names or structu
 In case of nested `data`, names of resulting headers will be concatenated by `'_'` symbol.
 
 # Keyword arguments
-- `delimiter::Union{Char, String} = ','`: the delimiter that will be used in the returned csv string.
+- `delimiter::Union{Char,String} = ','`: the delimiter that will be used in the returned csv string.
 - `headers::Vector{String} = String[]`: specifies which column headers will be used and in what order.
 - `with_names::Bool = true`: determines if column headers are included in the CSV output.
 # Examples
@@ -88,7 +88,7 @@ val,str
 """
 function to_csv(
     data::AbstractVector{T};
-    delimiter::Union{AbstractChar, AbstractString} = ',',
+    delimiter::Union{AbstractChar,AbstractString} = ',',
     headers::AbstractVector{<:AbstractString} = String[],
     with_names::Bool = true,
 ) where {T}
@@ -110,12 +110,12 @@ end
 
 function to_csv(
     data::AbstractVector{T};
-    delimiter::Union{AbstractChar, AbstractString} = ',',
+    delimiter::Union{AbstractChar,AbstractString} = ',',
     headers::AbstractVector{<:AbstractString} = String[],
     with_names::Bool = true,
-) where {T <: AbstractDict}
+) where {T<:AbstractDict}
     delimiter = parse_delimiter(delimiter)
-    flattened_data = to_flatten.(Dict{String, rec_valtype(T)}, data)
+    flattened_data = to_flatten.(Dict{String,rec_valtype(T)}, data)
     if isempty(headers)
         headers = Iterators.flatten(keys.(flattened_data)) |> unique |> sort
     end
@@ -127,7 +127,7 @@ function to_csv(
     return String(take!(io))
 end
 
-function parse_delimiter(delimiter::Union{AbstractChar, AbstractString})
+function parse_delimiter(delimiter::Union{AbstractChar,AbstractString})
     if length(delimiter) != 1 || first(delimiter) in INVALID_DELIMITERS
         throw(ArgumentError("invalid delimiter: `$(repr(delimiter))`"))
     end
@@ -193,7 +193,7 @@ end
     data::AbstractVector{T},
     ::Val{CK},
     delimiter::AbstractChar,
-) where {T, CK}
+) where {T,CK}
     print_records_exprs = []
     for i in eachindex(CK)
         value_expr = getcompkey_expr(:item, CK[i])

--- a/src/Ser/SerCsv.jl
+++ b/src/Ser/SerCsv.jl
@@ -2,71 +2,39 @@ module SerCsv
 
 export to_csv
 
-import ..to_flatten, ..issimple
+using Dates
+import ..to_flatten
 
-const WRAPPED = Set{Char}(['"', ',', ';', '\n'])
+const QUOTE = '"'
+const WRAPPED = [QUOTE, '\n']
 
-function qualify_text(s::AbstractString)
-    if any(c -> c in WRAPPED, s)
-        escaped_s = replace(s, "\"" => "\"\"")
-        return "\"$escaped_s\""
-    end
-    return s
-end
-
-function to_keys(
-    data::AbstractDict{K,V};
-    delimiter::AbstractString = "_",
-) where {K,V}
-    result = String[]
-    for (key, value) in data
-        if isa(value, AbstractDict)
-            for k in to_keys(value; delimiter = delimiter)
-                push!(result, string(key) * delimiter * k)
-            end
-        else
-            push!(result, string(key))
-        end
-    end
-    return result
-end
-
-function to_keys(
-    data::T;
-    delimiter::AbstractString = "_",
-) where {T}
-    result = String[]
-    for key in fieldnames(T)
-        value = getproperty(data, key)
-        if !issimple(value)
-            for k in to_keys(value; delimiter = delimiter)
-                push!(result, string(key) * delimiter * k)
-            end
-        else
-            push!(result, string(key))
-        end
-    end
-    return result
-end
+isatomictype(::Type{<:Any}) = false
+isatomictype(::Type{<:AbstractString}) = true
+isatomictype(::Type{Symbol}) = true
+isatomictype(::Type{<:AbstractChar}) = true
+isatomictype(::Type{<:Number}) = true
+isatomictype(::Type{<:Enum}) = true
+isatomictype(::Type{<:Type}) = true
+isatomictype(::Type{<:Dates.TimeType}) = true
 
 """
-    to_csv(data::Vector{T}; kw...) -> String
+    to_csv(data::AbstractVector{T}; kw...) -> String
 
-Uses `data` element values to make csv rows with fieldnames as columns headers. Type `T` may be a nested dictionary or a custom type.
-In case of nested `data`, names of resulting headers will be concatenate by "_" symbol using dictionary key-names or structure field names.
+Uses `data` element values to make csv rows with dictionary key-names or structure field names as columns headers. Type `T` may be a nested dictionary or a custom type.
+In case of nested `data`, names of resulting headers will be concatenated by `'_'` symbol.
 
-## Keyword arguments
-- `delimiter::String = ","`: The delimiter that will be used in the returned csv string.
-- `headers::Vector{String} = String[]`: Specifies which column headers will be used and in what order.
-- `with_names::Bool = true`: Determines if column headers are included in the CSV output (true to include, false to exclude).
-## Examples
+# Keyword arguments
+- `delimiter::AbstractChar = ','`: the delimiter that will be used in the returned csv string.
+- `headers::AbstractVector{<:AbstractString} = String[]`: specifies which column headers will be used and in what order.
+- `include_headers::Bool = true`: determines if column headers are included in the CSV output.
+# Examples
 
-Converting a vector of regular dictionaries with fixed headers order.
+Converting a vector of regular dictionaries with fixed headers order:
 
 ```julia-repl
 julia> data = [
            Dict("id" => 1, "name" => "Jack"),
-           Dict( "id" => 2, "name" => "Bob"),
+           Dict("id" => 2, "name" => "Bob"),
        ];
 
 julia> to_csv(data, headers = ["name", "id"]) |> print
@@ -75,7 +43,7 @@ Jack,1
 Bob,2
 ```
 
-Converting a vector of nested dictionaries with custom separator symbol.
+Converting a vector of nested dictionaries with custom delimiter symbol:
 
 ```julia-repl
 julia> data = [
@@ -84,20 +52,20 @@ julia> data = [
                "sub" => Dict(
                    "level" => 2,
                    "sub" => Dict(
-                       "level" => 3
+                       "level" => 3,
                    ),
                ),
            ),
            Dict(:level => 1),
        ];
 
-julia> to_csv(data, separator = "|") |> print
+julia> to_csv(data, delimiter = '|') |> print
 level|sub_level|sub_sub_level
 1|2|3
 1||
 ```
 
-Converting a vector of custom structures.
+Converting a vector of custom structures:
 
 ```julia-repl
 julia> struct Foo
@@ -111,51 +79,222 @@ julia> data = [Foo(1, "a"), Foo(2, "b")]
  Foo(2, "b")
 
 julia> to_csv(data) |> print
-str,val
-a,1
-b,2
+val,str
+1,a
+2,b
 ```
 """
 function to_csv(
-    data::Vector{T};
-    delimiter::String = ",",
-    headers::Vector{String} = String[],
-    with_names::Bool = true,
+    data::AbstractVector{T};
+    delimiter::AbstractChar = ',',
+    headers::AbstractVector{<:AbstractString} = String[],
+    include_headers::Bool = true,
 )::String where {T}
-    out_data = Vector{Dict{String,Any}}(undef, length(data) + with_names)
-    uni_keys = Set{String}()
-    ord_keys = String[]
+    comp_keys, headers = compkeys_and_headers(T, headers)
 
-    for (index, item) in enumerate(data)
-        flt_data = to_flatten(item)
-        new_keys = setdiff(keys(flt_data), uni_keys)
-        if !isempty(new_keys)
-            union!(uni_keys, new_keys)
-            append!(ord_keys, setdiff(to_keys(item), ord_keys))
-        end
-        out_data[index + with_names] = flt_data
-    end
-
-    if with_names
-        out_data[1] = Dict{String,String}(ord_keys .=> ord_keys)
-    end
-
-    out_cols = isempty(headers) ? ord_keys : headers
     io = IOBuffer()
-    last_col = out_cols[end]
+    temp_buff = IOBuffer()
 
-    try
-        for item in out_data
-            for col in out_cols
-                val = get(item, col, nothing)
-                str = val === nothing ? "" : qualify_text(string(val))
-                print(io, str, col != last_col ? delimiter : "\n")
+    include_headers && print_csv_headers(io, temp_buff, headers, delimiter)
+
+    Base.ensureroom(io, length(comp_keys) * length(data))
+
+    for item in data
+        print_csv_line(io, temp_buff, item, Val(comp_keys), delimiter)
+    end
+
+    return String(take!(io))
+end
+
+function to_csv(
+    data::AbstractVector{<:AbstractDict};
+    delimiter::AbstractChar = ',',
+    headers::AbstractVector{<:AbstractString} = String[],
+    include_headers::Bool = true,
+)::String
+    flattened_data, headers = flattened_data_and_headers(data, headers)
+
+    io = IOBuffer()
+
+    include_headers && print_csv_headers(io, headers, delimiter)
+
+    for item in flattened_data
+        print_csv_line(io, item, headers, delimiter)
+    end
+
+    return String(take!(io))
+end
+
+function print_csv_headers(
+    io::IOBuffer,
+    headers::AbstractVector{<:AbstractString},
+    delimiter::AbstractChar,
+)
+    print(io, string_quoted(first(headers), delimiter))
+
+    for i in eachindex(headers)[2:end]
+        print(io, delimiter, string_quoted(headers[i], delimiter))
+    end
+
+    println(io)
+end
+
+function print_csv_headers(
+    io::IOBuffer,
+    temp_buff::IOBuffer,
+    headers::AbstractVector{<:AbstractString},
+    delimiter::AbstractChar,
+)
+    print(temp_buff, first(headers))
+    copyquoted(io, temp_buff, delimiter)
+
+    for i in eachindex(headers)[2:end]
+        print(io, delimiter)
+        truncate(temp_buff, 0)
+        print(temp_buff, headers[i])
+        copyquoted(io, temp_buff, delimiter)
+    end
+
+    println(io)
+end
+
+function print_csv_line(
+    io::IOBuffer,
+    item::Dict{String, Any},
+    headers::AbstractVector{<:AbstractString},
+    delimiter::AbstractChar,
+)
+    val = get(item, first(headers), nothing)
+    print(io, string_quoted(val, delimiter))
+
+    for i in eachindex(headers)[2:end]
+        val = get(item, headers[i], nothing)
+        print(io, delimiter, string_quoted(val, delimiter))
+    end
+
+    println(io)
+end
+
+@generated function print_csv_line(
+    io::IOBuffer,
+    temp_buff::IOBuffer,
+    item,
+    ::Val{CK},
+    delimiter::AbstractChar,
+) where {CK}
+    body_exprs = []
+
+    for i in 1:length(CK)
+        getprop_expr = :(item)
+        for key in CK[i]
+            getprop_expr = :($(getprop_expr).$(key))
+        end
+
+        push!(body_exprs,
+            quote
+                truncate(temp_buff, 0)
+                print(temp_buff, $(getprop_expr))
+                copyquoted(io, temp_buff, delimiter)
+            end
+        )
+
+        if i < length(CK)
+            push!(body_exprs, quote print(io, delimiter) end)
+        end
+    end
+
+    push!(body_exprs, quote println(io) end)
+
+    body = quote $(body_exprs...) end
+    return body
+end
+
+function string_quoted(x, delimiter::AbstractChar)
+    s = isnothing(x) ? "" : string(x)
+    if occursin(delimiter, s) || any(c -> c in WRAPPED, s)
+        return string(QUOTE, replace(s, QUOTE => QUOTE^2), QUOTE)
+    end
+    return s
+end
+
+function copyquoted(dst::IOBuffer, src::IOBuffer, delimiter::AbstractChar)
+    quoted = false
+    quotes = 0
+    seekstart(src)
+    while !eof(src)
+        ch = read(src, Char)
+        if ch == delimiter || ch in WRAPPED
+            quoted = true
+        end
+        if ch == QUOTE
+            quotes += 1
+        end
+    end
+
+    nb = position(src)
+    Base.ensureroom(dst, nb + quoted * (2 + quotes))
+
+    quoted && print(dst, QUOTE)
+
+    seekstart(src)
+    while !eof(src)
+        ch = read(src, Char)
+        print(dst, ch)
+        ch == QUOTE && print(dst, ch)
+    end
+
+    quoted && print(dst, QUOTE)
+    return
+end
+
+function flattened_data_and_headers(
+    data::AbstractVector{<:AbstractDict},
+    custom_headers::AbstractVector{<:AbstractString},
+)
+    flattened_data = to_flatten.(data)
+    all_headers = unique(Iterators.flatten(keys.(flattened_data))) |> sort
+    headers = isempty(custom_headers) ? all_headers : custom_headers
+
+    return (flattened_data, headers)
+end
+
+function compkeys_and_headers(
+    ::Type{T},
+    custom_headers::AbstractVector{<:AbstractString},
+) where {T}
+    all_comp_keys = composite_keys(T)
+    all_headers = [join(string.(key), '_') for key in all_comp_keys]
+
+    if isempty(custom_headers)
+        return (Tuple(all_comp_keys), all_headers)
+    end
+
+    comp_keys = Tuple[]
+    headers = custom_headers
+    headers_idxs_map = Dict(header => i for (i, header) in enumerate(all_headers))
+
+    for header in headers
+        idx = get(headers_idxs_map, header, nothing)
+        isnothing(idx) && throw(ArgumentError("invalid header name: $(header)"))
+        push!(comp_keys, all_comp_keys[idx])
+    end
+
+    return (Tuple(comp_keys), headers)
+end
+
+function composite_keys(::Type{<:T}) where {T}
+    res = Tuple[]
+    for (key, type) in zip(fieldnames(T), fieldtypes(T))
+        if isatomictype(type) || !isconcretetype(type)
+            push!(res, (key,))
+        else
+            for subkeys in composite_keys(type)
+                push!(res, (key, subkeys...))
             end
         end
-        return String(take!(io))
-    finally
-        close(io)
     end
+
+    return res
 end
 
 end

--- a/src/Utl/Utl.jl
+++ b/src/Utl/Utl.jl
@@ -15,11 +15,11 @@ issimple(::TimeType)::Bool = true
 
 rec_valtype(x::T) where {T} = rec_valtype(T)
 rec_valtype(::Type{<:Any}) = Any
-rec_valtype(::Type{<:AbstractDict{<:Any, V}}) where {V} = V
-rec_valtype(::Type{<:AbstractDict{<:Any, V}}) where {V <: AbstractDict} = rec_valtype(V)
+rec_valtype(::Type{<:AbstractDict{<:Any,V}}) where {V} = V
+rec_valtype(::Type{<:AbstractDict{<:Any,V}}) where {V<:AbstractDict} = rec_valtype(V)
 
 """
-    to_flatten([dict_type=Dict{String, Any}], data; delimiter = '_') -> dict_type
+    to_flatten([dict_type=Dict{String,Any}], data; delimiter = '_') -> dict_type
 
 Transforms a nested dictionary `data` (or custom type) into a single-level dictionary. The keys in the new dictionary are created by joining the nested keys (or fieldnames) with `delimiter` symbol.
 
@@ -38,13 +38,13 @@ julia> nested_dict = Dict(
            ),
        );
 
-julia> to_flatten(nested_dict; delimiter="__")
+julia> to_flatten(nested_dict; delimiter = "__")
 Dict{String, Any} with 3 entries:
   "bar__foo"      => 2
   "bar__baz__foo" => 3
   "foo"           => 1
 
-julia> to_flatten(Dict{String, Int}, nested_dict; delimiter="__")
+julia> to_flatten(Dict{String,Int}, nested_dict; delimiter = "__")
 Dict{String, Int64} with 3 entries:
   "bar__foo"      => 2
   "bar__baz__foo" => 3
@@ -76,12 +76,12 @@ Dict{String, Any} with 3 entries:
 function to_flatten(
     ::Type{D},
     data::AbstractDict;
-    delimiter::Union{AbstractChar, AbstractString} = '_',
-) where {V, D <: AbstractDict{String, V}}
+    delimiter::Union{AbstractChar,AbstractString} = '_',
+) where {V,D<:AbstractDict{String,V}}
     result = D()
     for (key, value) in data
         if value isa AbstractDict
-            for (k, v) in to_flatten(Dict{String, V}, value; delimiter)
+            for (k, v) in to_flatten(Dict{String,V}, value; delimiter)
                 result[string(key) * delimiter * k] = v
             end
         else
@@ -94,13 +94,13 @@ end
 function to_flatten(
     ::Type{D},
     data::T;
-    delimiter::Union{AbstractChar, AbstractString} = '_',
-) where {T, D <: AbstractDict{String}}
+    delimiter::Union{AbstractChar,AbstractString} = '_',
+) where {T,V,D<:AbstractDict{String,V}}
     result = D()
     for key in fieldnames(T)
         value = getproperty(data, key)
         if !issimple(value)
-            for (k, v) in to_flatten(D, value; delimiter)
+            for (k, v) in to_flatten(Dict{String,V}, value; delimiter)
                 result[string(key) * delimiter * k] = v
             end
         else
@@ -113,8 +113,8 @@ end
 # kwarg dict_type for backward compatibility
 function to_flatten(
     data::Any;
-    dict_type::Type{D} = Dict{String, rec_valtype(data)},
-    delimiter::Union{AbstractChar, AbstractString} = '_',
-) where {D <:AbstractDict{String}}
+    dict_type::Type{D} = Dict{String,rec_valtype(data)},
+    delimiter::Union{AbstractChar,AbstractString} = '_',
+) where {D<:AbstractDict{String}}
     return to_flatten(D, data; delimiter)
 end

--- a/test/Ser/SerCsv.jl
+++ b/test/Ser/SerCsv.jl
@@ -9,7 +9,7 @@
             d_value::String
         end
 
-        exp_obj = [
+        data = [
             SimpleRecord(1, "a", 11, "11.1"),
             SimpleRecord(2, "b", 22, "bb"),
             SimpleRecord(2, "b", 22, "bb"),
@@ -20,7 +20,7 @@
         2,b,22,bb
         2,b,22,bb
         """
-        @test Serde.to_csv(exp_obj) |> strip == exp_str |> strip
+        @test Serde.to_csv(data) |> strip == exp_str |> strip
     end
 
     @testset "Case 2: Normalization with Nested Structures" begin
@@ -40,7 +40,7 @@
             data::SubRecord
         end
 
-        exp_obj = [
+        data = [
             ComplexRecord(1, "Hello", 3, SubRecord(42, NestedDetail("Nested object1"))),
             ComplexRecord(2, "Julia", 5, SubRecord(43, NestedDetail("Nested object2"))),
             ComplexRecord(3, "Coconut", 7, SubRecord(44, NestedDetail("Nested object3"))),
@@ -52,7 +52,7 @@
         3,Coconut,7,44,Nested object3
         """
         @test Serde.to_csv(
-            exp_obj,
+            data,
             headers = ["id", "name", "count", "data_code", "data_nested_detail"],
         ) |> strip == exp_str |> strip
     end
@@ -65,7 +65,7 @@
             value::String
         end
 
-        exp_obj = [
+        data = [
             SpecialCharRecord(1, "a,,,,;", 11, "11.1"),
             SpecialCharRecord(2, "b\nl", 22, "bb\"\""),
             SpecialCharRecord(1, "a,,,,;", 12, "11.1"),
@@ -77,26 +77,26 @@
         l",22,"bb\"\"\"\""
         1,"a,,,,;",12,11.1
         """
-        @test Serde.to_csv(exp_obj, headers = ["id", "text", "count", "value"]) |> strip ==
+        @test Serde.to_csv(data, headers = ["id", "text", "count", "value"]) |> strip ==
               exp_str |> strip
     end
 
     @testset "Case 4: Serializing Dictionaries" begin
-        exp_obj = [
+        data = [
             IdDict("a" => 10, "B" => 20),
             Dict("a" => 15, "B" => 32),
             WeakKeyDict("a" => 10, "B" => 35),
         ]
         expected_csv_with_delimiter = """
-        a;B
-        10;20
-        15;32
-        10;35
+        B;a
+        20;10
+        32;15
+        35;10
         """
-        @test Serde.to_csv(exp_obj; delimiter = ";") |> strip ==
+        @test Serde.to_csv(data; delimiter = ';') |> strip ==
               expected_csv_with_delimiter |> strip
 
-        exp_obj = [
+        data = [
             Dict("a" => 10, "B" => 20, "C" => Dict("cfoo" => "foo", "cbaz" => "baz")),
             Dict(:a => 10, :B => 20),
         ]
@@ -105,14 +105,14 @@
         10,20,baz,foo
         10,20,,
         """
-        @test Serde.to_csv(exp_obj, headers = ["a", "B", "C_cbaz", "C_cfoo"], with_names = true) |> strip ==
+        @test Serde.to_csv(data, headers = ["a", "B", "C_cbaz", "C_cfoo"], include_headers = true) |> strip ==
               exp_str |> strip
 
         exp_str = """
         10,20,baz,foo
         10,20,,
         """
-        @test Serde.to_csv(exp_obj, headers = ["a", "B", "C_cbaz", "C_cfoo"], with_names = false) |> strip ==
+        @test Serde.to_csv(data, headers = ["a", "B", "C_cbaz", "C_cfoo"], include_headers = false) |> strip ==
               exp_str |> strip
     end
 

--- a/test/Ser/SerCsv.jl
+++ b/test/Ser/SerCsv.jl
@@ -105,14 +105,14 @@
         10,20,baz,foo
         10,20,,
         """
-        @test Serde.to_csv(data, headers = ["a", "B", "C_cbaz", "C_cfoo"], include_headers = true) |> strip ==
+        @test Serde.to_csv(data, headers = ["a", "B", "C_cbaz", "C_cfoo"], with_names = true) |> strip ==
               exp_str |> strip
 
         exp_str = """
         10,20,baz,foo
         10,20,,
         """
-        @test Serde.to_csv(data, headers = ["a", "B", "C_cbaz", "C_cfoo"], include_headers = false) |> strip ==
+        @test Serde.to_csv(data, headers = ["a", "B", "C_cbaz", "C_cfoo"], with_names = false) |> strip ==
               exp_str |> strip
     end
 

--- a/test/Utl/Utl.jl
+++ b/test/Utl/Utl.jl
@@ -6,13 +6,13 @@
 
         exp_obj = Dict("value" => 1, "sub_value" => 2, "sub_sub_value" => 3)
         @test to_flatten(data) == exp_obj
-        @test to_flatten(Dict{String, Int}, data) == exp_obj
-        @test to_flatten(Dict{String, Int}, data) isa Dict{String, Int}
+        @test to_flatten(Dict{String,Int}, data) == exp_obj
+        @test to_flatten(Dict{String,Int}, data) isa Dict{String,Int}
 
         exp_obj = Dict("value" => 1, "subvalue" => 2, "subsubvalue" => 3)
         @test to_flatten(data; delimiter = "") == exp_obj
-        @test to_flatten(Dict{String, Int}, data; delimiter="") == exp_obj
-        @test to_flatten(Dict{String, Int}, data; delimiter="") isa Dict{String, Int}
+        @test to_flatten(Dict{String,Int}, data; delimiter="") == exp_obj
+        @test to_flatten(Dict{String,Int}, data; delimiter="") isa Dict{String,Int}
 
         data = Dict(:a => Dict(:b => 1, :c => 2), :b => Dict(:d => 3, :e => 4))
         exp_obj = Dict("a_b" => 1, "a_c" => 2, "b_d" => 3, "b_e" => 4)
@@ -25,12 +25,16 @@
             sub::Union{Nothing,Nested}
         end
 
+        data = Nested(1, Nested(2, Nested(3, nothing)))
+
         exp_kvs = Dict{String,Int64}("value" => 1, "sub_value" => 2, "sub_sub_value" => 3)
-        exp_obj = Nested(1, Nested(2, Nested(3, nothing)))
-        @test to_flatten(exp_obj) == exp_kvs
+        @test to_flatten(data) == exp_kvs
+        @test to_flatten(Dict{String,Int}, data) == exp_kvs
+        @test to_flatten(Dict{String,Int}, data) isa Dict{String,Int}
 
         exp_kvs = Dict{String,Int64}("value" => 1, "subvalue" => 2, "subsubvalue" => 3)
-        exp_obj = Nested(1, Nested(2, Nested(3, nothing)))
-        @test to_flatten(exp_obj; delimiter = "") == exp_kvs
+        @test to_flatten(data; delimiter = "") == exp_kvs
+        @test to_flatten(Dict{String,Int}, data; delimiter = "") == exp_kvs
+        @test to_flatten(Dict{String,Int}, data; delimiter = "") isa Dict{String,Int}
     end
 end

--- a/test/Utl/Utl.jl
+++ b/test/Utl/Utl.jl
@@ -2,17 +2,21 @@
 
 @testset verbose = true "Utl" begin
     @testset "Case №1: Nested dictionary" begin
-        exp_kvs = Dict(:value => 1, :sub => Dict(:value => 2, :sub => Dict(:value => 3)))
-        exp_obj = Dict{String,Int64}("value" => 1, "sub_value" => 2, "sub_sub_value" => 3)
-        @test to_flatten(exp_kvs) == exp_obj
+        data = Dict(:value => 1, :sub => Dict(:value => 2, :sub => Dict(:value => 3)))
 
-        exp_kvs = Dict(:value => 1, :sub => Dict(:value => 2, :sub => Dict(:value => 3)))
-        exp_obj = Dict{String,Int64}("value" => 1, "subvalue" => 2, "subsubvalue" => 3)
-        @test to_flatten(exp_kvs; delimiter = "") == exp_obj
+        exp_obj = Dict("value" => 1, "sub_value" => 2, "sub_sub_value" => 3)
+        @test to_flatten(data) == exp_obj
+        @test to_flatten(Dict{String, Int}, data) == exp_obj
+        @test to_flatten(Dict{String, Int}, data) isa Dict{String, Int}
 
-        exp_kvs = Dict(:a => Dict(:b => 1, :c => 2), :b => Dict(:d => 3, :e => 4))
-        exp_obj = Dict{String,Int64}("a_b" => 1, "a_c" => 2, "b_d" => 3, "b_e" => 4)
-        @test to_flatten(exp_kvs) == exp_obj
+        exp_obj = Dict("value" => 1, "subvalue" => 2, "subsubvalue" => 3)
+        @test to_flatten(data; delimiter = "") == exp_obj
+        @test to_flatten(Dict{String, Int}, data; delimiter="") == exp_obj
+        @test to_flatten(Dict{String, Int}, data; delimiter="") isa Dict{String, Int}
+
+        data = Dict(:a => Dict(:b => 1, :c => 2), :b => Dict(:d => 3, :e => 4))
+        exp_obj = Dict("a_b" => 1, "a_c" => 2, "b_d" => 3, "b_e" => 4)
+        @test to_flatten(data) == exp_obj
     end
 
     @testset "Case №2: Nested type" begin


### PR DESCRIPTION
`to_csv` has been optimized by eliminating type instability for the case of an array of custom structures

Example (Julia 1.10.9):
```julia
using Dates, Random, BenchmarkTools
data = map(x -> (now(), randstring(), rand()), 1:10_000_000)
@btime to_csv($data)
# was: 104.411 s (431983230 allocations: 28.22 GiB)
# became: 16.212 s (201966011 allocations: 14.02 GiB)
data = map(x -> (randstring(), (randstring(), randstring())), 1:10_000_000)
@btime to_csv($data)
# was: 133.076 s (400000074 allocations: 23.59 GiB)
# became: 2.740 s (61 allocations: 779.07 MiB)
data = map(
    x -> Dict(
        "datetime" => now(),
        "str" => randstring(),
        "nums" => Dict("float" => rand(), "int" => rand(Int)),
    ), 1:1_000_000)
@btime to_csv($data)
# was: 9.176 s (55199221 allocations: 3.60 GiB)
# became: 5.770 s (33198552 allocations: 2.64 GiB)
```

Example (Julia 1.11.5):
```julia
using Dates, Random, BenchmarkTools
data = map(x -> (now(), randstring(), rand()), 1:10_000_000)
@btime to_csv($data)
# 36.470 s (451980911 allocations: 23.22 GiB)
# became: 14.080 s (211978280 allocations: 11.34 GiB)
data = map(x -> (randstring(), (randstring(), randstring())), 1:10_000_000)
@btime to_csv($data)
# was: 46.786 s (400000095 allocations: 20.32 GiB)
# became: 2.898 s (70 allocations: 779.07 MiB)
data = map(
    x -> Dict(
        "datetime" => now(),
        "str" => randstring(),
        "nums" => Dict("float" => rand(), "int" => rand(Int)),
    ), 1:1_000_000)
@btime to_csv($data)
# was: 5.432 s (57195581 allocations: 3.10 GiB)
# became: 4.072 s (34196647 allocations: 2.23 GiB)
```

`to_flatten` has also been optimized by moving the keyword argument `dict_type` to positional arguments

Example:
```julia
using Serde
using BenchmarkTools

d = Dict(string(i) => i for i in 1:1_000_000)
@btime to_flatten(d)
# was: 187.311 ms (999548 allocations: 80.42 MiB)
# became: 165.151 ms (59 allocations: 65.17 MiB)
@btime to_flatten(Dict{String, Int}, d)
# was: 161.540 ms (63 allocations: 65.17 MiB)
# became: 169.940 ms (59 allocations: 65.17 MiB)
d = Dict(
    :v => 1,
    :d1 => Dict(string(i) => i for i in 1:100_000),
    :d2 => Dict(i => Dict(:v => 1, :d => Dict(:v => 1)) for i in 1:100_000),
)
@btime to_flatten(d)
# was: 568.843 ms (6198710 allocations: 274.99 MiB)
# became: 251.693 ms (2599627 allocations: 163.61 MiB)
@btime to_flatten(Dict{String, Int}, d)
# was: 541.613 ms (7398714 allocations: 311.61 MiB)
# became: 239.691 ms (2500138 allocations: 162.09 MiB)
```

Platform info:
```julia-repl
julia> versioninfo()
Julia Version 1.11.5
Commit 760b2e5b739 (2025-04-14 06:53 UTC)
Build Info:
  Official https://julialang.org/ release
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 16 × AMD Ryzen 7 5800H with Radeon Graphics
  WORD_SIZE: 64
  LLVM: libLLVM-16.0.6 (ORCJIT, znver3)
Threads: 1 default, 0 interactive, 1 GC (on 16 virtual cores)
Environment:
  JULIA_PROJECT = @.
```  