### PR TITLE
Fix `SerToml.to_toml` for empty vector

### DIFF
--- a/src/Ser/SerToml.jl
+++ b/src/Ser/SerToml.jl
@@ -137,7 +137,7 @@ end
 
 function toml_pair(key, val::AbstractVector{T}; level::Int64 = 0, kw...)::String where {T}
     if isempty(val)
-        return indent(level) * "$key = []"
+        return indent(level) * "$key = []" * "\n"
     elseif issimple(val[1])
         return create_simple_vector(key, val; level = level, kw...)
     else

--- a/test/Ser/SerToml.jl
+++ b/test/Ser/SerToml.jl
@@ -116,6 +116,21 @@
                 UUID("f47ac10b-58cc-4372-a567-0e02b2c3d479"),
             ),
         ) == exp_str
+
+        exp_str = """
+        test = 100
+        bar1 = 1
+        bar2 = []
+        uuid = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+        """
+        @test Serde.to_toml(
+            Fooo(
+                100,
+                Bar1(100, "ds"),
+                [],
+                UUID("f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+            ),
+        ) == exp_str
     end
 
     @testset "Case №3: Vectors witexp_kvs mixed types" begin


### PR DESCRIPTION
```julia
(jl_gB87ZN) pkg> status
Status `~\AppData\Local\Temp\jl_gB87ZN\Project.toml`
  [db9b398d] Serde v3.6.1

julia> using Serde; @kwdef struct St1
           a = 0
           b = Int[]
           c = 0
           d = Int[]
           e = 0
       end; x1 = St1()
St1(0, Int64[], 0, Int64[], 0)

julia> to_toml(x1)
"a = 0\nb = []c = 0\nd = []e = 0\n"

julia> to_toml(x1) |> print
a = 0
b = []c = 0
d = []e = 0
```

### Pull request checklist

- [x] Did you add a description to the Pull Request?
- [x] Did you add new tests?
- [x] Did you add reviewers?

