### PR TITLE
Formatting cleanup & CI dependency bumps

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,15 +34,15 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@latest
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(; path = pwd())); Pkg.instantiate();'
       - name: Build and deploy
@@ -68,7 +68,7 @@ jobs:
         run: julia --project=docs/ docs/make.jl
       - name: Make comment with preview link
         if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened'}}
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.createComment({

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Serde"
 uuid = "db9b398d-9517-45f8-9a95-92af99003e0e"
-version = "3.7.1"
+version = "3.7.2"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/De/De.jl
+++ b/src/De/De.jl
@@ -1,4 +1,4 @@
-# De/De
+#__ De/De
 
 abstract type DeserError <: Exception end
 

--- a/src/De/Deser.jl
+++ b/src/De/Deser.jl
@@ -1,4 +1,4 @@
-# De/Deser
+#__ De/Deser
 
 """
     ClassType
@@ -386,9 +386,11 @@ function deser(::CustomType, ::Type{T}, data::AbstractVector{A})::T where {T<:An
         val_i = get(data, i, nulltype(F_i))
         push!(others, eldeser(T, F_i, i, val_i))
     end
-    return constructor(x_1, x_2, x_3, x_4, x_5, x_6, x_7, x_8, x_9, x_10, x_11, x_12, x_13,
-                       x_14, x_15, x_16, x_17, x_18, x_19, x_20, x_21, x_22, x_23, x_24, x_25,
-                       x_26, x_27, x_28, x_29, x_30, x_31, x_32, others...)
+    return constructor(
+        x_1, x_2, x_3, x_4, x_5, x_6, x_7, x_8, x_9, x_10, x_11, x_12, x_13,
+        x_14, x_15, x_16, x_17, x_18, x_19, x_20, x_21, x_22, x_23, x_24, x_25,
+        x_26, x_27, x_28, x_29, x_30, x_31, x_32, others...,
+    )
 end
 
 function deser(::CustomType, ::Type{T}, data::AbstractDict{K,D})::T where {T<:Any,K<:Union{AbstractString,Symbol},D<:Any}
@@ -414,9 +416,11 @@ function deser(::CustomType, ::Type{T}, data::AbstractDict{K,D})::T where {T<:An
         val_i = (isnothing(val_i) || ismissing(val_i) || isempty(T, val_i)) ? nulltype(F_i) : val_i
         push!(others, eldeser(T, F_i, key_i, val_i))
     end
-    return constructor(x_1, x_2, x_3, x_4, x_5, x_6, x_7, x_8, x_9, x_10, x_11, x_12, x_13,
-                       x_14, x_15, x_16, x_17, x_18, x_19, x_20, x_21, x_22, x_23, x_24, x_25,
-                       x_26, x_27, x_28, x_29, x_30, x_31, x_32, others...)
+    return constructor(
+        x_1, x_2, x_3, x_4, x_5, x_6, x_7, x_8, x_9, x_10, x_11, x_12, x_13,
+        x_14, x_15, x_16, x_17, x_18, x_19, x_20, x_21, x_22, x_23, x_24, x_25,
+        x_26, x_27, x_28, x_29, x_30, x_31, x_32, others...,
+    )
 end
 
 function deser(::CustomType, ::Type{T}, data::NamedTuple)::T where {T}
@@ -440,7 +444,9 @@ function deser(::CustomType, ::Type{T}, data::NamedTuple)::T where {T}
         val_i = (isnothing(val_i) || ismissing(val_i) || isempty(T, val_i)) ? nulltype(F_i) : val_i
         push!(others, eldeser(T, F_i, key_i, val_i))
     end
-    return constructor(x_1, x_2, x_3, x_4, x_5, x_6, x_7, x_8, x_9, x_10, x_11, x_12, x_13,
-                       x_14, x_15, x_16, x_17, x_18, x_19, x_20, x_21, x_22, x_23, x_24, x_25,
-                       x_26, x_27, x_28, x_29, x_30, x_31, x_32, others...)
+    return constructor(
+        x_1, x_2, x_3, x_4, x_5, x_6, x_7, x_8, x_9, x_10, x_11, x_12, x_13,
+        x_14, x_15, x_16, x_17, x_18, x_19, x_20, x_21, x_22, x_23, x_24, x_25,
+        x_26, x_27, x_28, x_29, x_30, x_31, x_32, others...,
+    )
 end

--- a/src/Par/Par.jl
+++ b/src/Par/Par.jl
@@ -1,4 +1,4 @@
-# Par/Par
+#__ Par/Par
 
 include("ParQuery.jl")
 using .ParQuery

--- a/src/Ser/Ser.jl
+++ b/src/Ser/Ser.jl
@@ -1,4 +1,4 @@
-# Ser/Ser
+#__ Ser/Ser
 
 (ser_name(::Type{T}, ::Val{x})::Symbol) where {T,x} = x
 (ser_value(::Type{T}, ::Val{x}, v::V)::V) where {T,x,V} = v

--- a/src/Serde.jl
+++ b/src/Serde.jl
@@ -3,7 +3,7 @@ module Serde
 function deser end
 function parse_value end
 
-# Ser
+#__ Ser
 export to_csv,
     to_json,
     to_pretty_json,
@@ -12,7 +12,7 @@ export to_csv,
     to_xml,
     to_yaml
 
-# De
+#__ De
 export deser_csv,
     deser_json,
     deser_query,
@@ -20,7 +20,7 @@ export deser_csv,
     deser_xml,
     deser_yaml
 
-# Par
+#__ Par
 export parse_csv,
     parse_json,
     parse_query,
@@ -28,7 +28,7 @@ export parse_csv,
     parse_xml,
     parse_yaml
 
-# Utl
+#__ Utl
 export @serde,
     @serde_pascal_case,
     @serde_camel_case,

--- a/src/Utl/Macros.jl
+++ b/src/Utl/Macros.jl
@@ -1,4 +1,4 @@
-# Utl/Macros
+#__ Utl/Macros
 
 function chain(::Val{Symbol("@default_value")}, struct_name::Symbol, field_name::String, default_value::Any)::Expr
     return quote

--- a/src/Utl/Utl.jl
+++ b/src/Utl/Utl.jl
@@ -1,4 +1,4 @@
-# Utl/Utl
+#__ Utl/Utl
 
 using Dates
 


### PR DESCRIPTION
## Summary
- Bump patch version 3.7.1 → 3.7.2
- Fix paren-alignment → 4-space indent in `Deser.jl`
- Bump julia-actions/setup-julia from 2 to 3
- Bump julia-actions/cache from 2 to 3
- Bump codecov/codecov-action from 5 to 6
- Bump actions/github-script from 8 to 9

Closes #101, closes #102, closes #103, closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)