### PR TITLE
Fix missing </th> closing tag in README HTML table

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Serde is a Julia library for (de)serializing data to/from various formats. The l
 <html>
   <body>
     <table>
-      <tr><th>Format</th><th><div align=center>JSON</div></th><th><div align=center>TOML</div></th><th><div align=center>XML</div></th><th><div align=center>YAML</div></th><th><div align=center>CSV</div><th><div align=center>Query</div></th><th><div align=center>MsgPack</div></th><th><div align=center>BSON</div></th></tr>
+      <tr><th>Format</th><th><div align=center>JSON</div></th><th><div align=center>TOML</div></th><th><div align=center>XML</div></th><th><div align=center>YAML</div></th><th><div align=center>CSV</div></th><th><div align=center>Query</div></th><th><div align=center>MsgPack</div></th><th><div align=center>BSON</div></th></tr>
       <tr>
         <td>Deserialization</td>
         <td><div align=center>✓</div></td>


### PR DESCRIPTION
## Summary
- Fix missing `</th>` closing tag on the CSV column header in the HTML formats table
- The line `<th><div align=center>CSV</div><th>` was missing its closing `</th>` before the next `<th>` tag