### PR TITLE
With: chain name strategies, strategy-aware tagged unions

### DIFF
--- a/src/deser.jl
+++ b/src/deser.jl
@@ -272,10 +272,10 @@ function deser(strategy, ::StructClass, ::Type{T}, data::AbstractDict{K,D}) wher
 end
 
 function deser(strategy, ::TaggedClass, ::Type{T}, data::AbstractDict{K,D}) where {T,K<:Union{AbstractString,Symbol},D}
-    tk = tag_key(T)
+    tk = tag_key(strategy, T)
     tag_val = get(data, isa(tk, K) ? tk : deser(K, tk), nothing)
     if tag_val !== nothing
-        for (tv, ST) in tag_subtypes(T)
+        for (tv, ST) in tag_subtypes(strategy, T)
             string(tag_val) == string(tv) && return deser(strategy, ST, data)
         end
     end

--- a/src/formats/Json.jl
+++ b/src/formats/Json.jl
@@ -297,11 +297,11 @@ function _yy_deser_struct(strategy, ::Type{T}, obj::Ptr{YYJSONVal}) where {T}
 end
 
 function _yy_deser_tagged(strategy, ::Type{T}, obj::Ptr{YYJSONVal}) where {T}
-    tk = string(tag_key(T))
+    tk = string(tag_key(strategy, T))
     tag_ptr = yyjson_obj_getn(obj, tk, sizeof(tk))
     tag_ptr === YYJSONVal_NULL && throw(Serde.TypeMismatchError(T, Symbol(tk), T, Nothing, nothing))
     tag_val = unsafe_string(yyjson_get_str(tag_ptr))
-    for (tv, ST) in tag_subtypes(T)
+    for (tv, ST) in tag_subtypes(strategy, T)
         string(tv) == tag_val && return _yy_deser_struct(strategy, ST, obj)
     end
     throw(Serde.TypeMismatchError(T, Symbol(tk), T, String, tag_val))

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -190,6 +190,8 @@ deser_validate(::Type{T}, ::Val{x}, value) where {T,x} = nothing
 @inline isempty_value(strategy, ::Type{T}, ::Val{x}, v) where {T,x} = isempty_value(T, Val(x), v)
 @inline deser_transform(strategy, ::Type{T}, ::Type{F}, v) where {T,F} = deser_transform(T, F, v)
 @inline deser_validate(strategy, ::Type{T}, ::Val{x}, v) where {T,x} = deser_validate(T, Val(x), v)
+@inline tag_key(strategy, ::Type{T}) where {T} = tag_key(T)
+@inline tag_subtypes(strategy, ::Type{T}) where {T} = tag_subtypes(T)
 
 """
     Serde.ser_name(::Type{T}, ::Val{field}) -> Symbol
@@ -311,6 +313,7 @@ ser_skip(::Type{T}, ::Val{x}, v) where {T,x} = ser_skip(T, Val(x))
 
 """
     Serde.tag_key(::Type{T}) -> Union{Nothing, Symbol, String}
+    Serde.tag_key(strategy, ::Type{T}) -> Union{Nothing, Symbol, String}
 
 Returns the name of the discriminator field for tagged-union type `T`.
 
@@ -331,6 +334,7 @@ tag_key(::Type{T}) where {T} = nothing
 
 """
     Serde.tag_subtypes(::Type{T}) -> Tuple
+    Serde.tag_subtypes(strategy, ::Type{T}) -> Tuple
 
 Returns a tuple of `(tag_value => SubType, ...)` pairs for the tagged union type `T`.
 

--- a/src/with.jl
+++ b/src/with.jl
@@ -9,13 +9,15 @@ well-defined combination rule per trait:
 
 | Trait | Rule |
 |---|---|
-| `ser_name` / `deser_name` | first-wins: use the first strategy that renames the field |
+| `ser_name` / `deser_name` | chain: apply each strategy in order |
 | `ser_skip` | OR: skip if any strategy says skip |
 | `ser_value` / `ser_type` / `deser_transform` | chain: apply each strategy in order |
 | `has_default` | OR: field has a default if any strategy provides one |
 | `deser_default` | first-wins: use the first strategy that has a default |
 | `isempty_value` | OR: treat as empty if any strategy says so |
 | `deser_validate` | all: run every strategy's validator |
+| `tag_key` | first-wins: use the first strategy that returns non-`nothing` |
+| `tag_subtypes` | merge: concatenate subtypes from all strategies |
 
 # Examples
 ```julia
@@ -39,22 +41,22 @@ end
 
 With(args...) = With(args)
 
-# ── ser_name: first-wins ──────────────────────────────────────────────────────
+# ── ser_name: chain ───────────────────────────────────────────────────────────
 
 _with_ser_name(::Tuple{}, ::Type{T}, ::Val{x}) where {T,x} = x
 function _with_ser_name(ctxs::Tuple, ::Type{T}, ::Val{x}) where {T,x}
     v = ser_name(first(ctxs), T, Val(x))
-    return v === x ? _with_ser_name(Base.tail(ctxs), T, Val(x)) : v
+    return _with_ser_name(Base.tail(ctxs), T, Val(v))
 end
 
 ser_name(w::With, ::Type{T}, ::Val{x}) where {T,x} = _with_ser_name(w.ctxs, T, Val(x))
 
-# ── deser_name: first-wins ────────────────────────────────────────────────────
+# ── deser_name: chain ─────────────────────────────────────────────────────────
 
 _with_deser_name(::Tuple{}, ::Type{T}, ::Val{x}) where {T,x} = x
 function _with_deser_name(ctxs::Tuple, ::Type{T}, ::Val{x}) where {T,x}
     v = deser_name(first(ctxs), T, Val(x))
-    return v === x ? _with_deser_name(Base.tail(ctxs), T, Val(x)) : v
+    return _with_deser_name(Base.tail(ctxs), T, Val(v))
 end
 
 deser_name(w::With, ::Type{T}, ::Val{x}) where {T,x} = _with_deser_name(w.ctxs, T, Val(x))
@@ -143,3 +145,22 @@ function _with_deser_validate(ctxs::Tuple, ::Type{T}, ::Val{x}, v) where {T,x}
 end
 
 deser_validate(w::With, ::Type{T}, ::Val{x}, v) where {T,x} = _with_deser_validate(w.ctxs, T, Val(x), v)
+
+# ── tag_key: first-wins (first non-nothing) ──────────────────────────────────
+
+_with_tag_key(::Tuple{}, ::Type{T}) where {T} = nothing
+function _with_tag_key(ctxs::Tuple, ::Type{T}) where {T}
+    v = tag_key(first(ctxs), T)
+    return v !== nothing ? v : _with_tag_key(Base.tail(ctxs), T)
+end
+
+tag_key(w::With, ::Type{T}) where {T} = _with_tag_key(w.ctxs, T)
+
+# ── tag_subtypes: merge ──────────────────────────────────────────────────────
+
+_with_tag_subtypes(::Tuple{}, ::Type{T}) where {T} = ()
+function _with_tag_subtypes(ctxs::Tuple, ::Type{T}) where {T}
+    return (tag_subtypes(first(ctxs), T)..., _with_tag_subtypes(Base.tail(ctxs), T)...)
+end
+
+tag_subtypes(w::With, ::Type{T}) where {T} = _with_tag_subtypes(w.ctxs, T)

--- a/test/test_with.jl
+++ b/test/test_with.jl
@@ -1,6 +1,6 @@
 @testset "With strategy composer" begin
 
-    # ── ser_name / deser_name: first-wins ─────────────────────────────────────
+    # ── ser_name / deser_name: chain ──────────────────────────────────────────
 
     @testset "With(CamelCase()) renames fields" begin
         struct _WithCamel
@@ -30,37 +30,28 @@
         @test obj.user_name == "Bob"
     end
 
-    @testset "first strategy wins for naming" begin
-        struct _WithNamingFirst
+    @testset "name strategies chain in order" begin
+        struct _WithNamingChain
             my_field::Int
         end
-        # Two CamelCase strategies — the first one wins (both rename to camelCase, same result)
-        w = With(CamelCase(), PascalCase())
-        # CamelCase wins: myField (not MyField from PascalCase)
-        @test Serde.ser_name(w, _WithNamingFirst, Val(:my_field)) == :myField
+        struct _TestPrefix end
+        Serde.ser_name(::_TestPrefix, ::Type{T}, ::Val{x}) where {T,x} = Symbol("api_" * string(x))
+        Serde.deser_name(::_TestPrefix, ::Type{T}, ::Val{x}) where {T,x} = Symbol("api_" * string(x))
+        # chain: Prefix first → api_my_field, then CamelCase → apiMyField
+        w = With(_TestPrefix(), CamelCase())
+        @test Serde.ser_name(w, _WithNamingChain, Val(:my_field)) == :apiMyField
+        @test Serde.deser_name(w, _WithNamingChain, Val(:my_field)) == :apiMyField
     end
 
-    @testset "unnamed fields fall through to type-level ser_name" begin
+    @testset "identity strategy is a no-op in chain" begin
         struct _WithFallthrough
             foo::Int
         end
         Serde.ser_name(::Type{_WithFallthrough}, ::Val{:foo}) = :FOO
-        # With(CamelCase()): CamelCase returns :foo (camelCase of "foo" = "foo"),
-        # which equals :foo, so falls through to next... but there's no next.
-        # Wait — actually CamelCase returns Symbol(to_camel_case("foo")) = :foo = x, so falls through.
-        # The _with_ser_name base case returns x = :foo.
-        # But type-level ser_name is NOT called by With directly; With calls strategy fallbacks.
-        # The type-level ser_name(T, Val(x)) is called via the generic fallback
-        # ser_name(strategy, T, Val(x)) = ser_name(T, Val(x)) when no strategy overrides.
-        # So for CamelCase: ser_name(CamelCase(), _WithFallthrough, Val(:foo)) = :foo (via CamelCase override).
-        # That equals :foo, so _with_ser_name falls through to base case returning :foo.
-        # The type-level override Serde.ser_name(::Type{_WithFallthrough}, ::Val{:foo}) = :FOO
-        # is NOT reached by With because With never calls ser_name(T, Val(x)) directly.
-        # This is by design: type-level overrides bypass With.
+        # CamelCase doesn't change "foo" (no underscores) → :foo, chain ends → :foo
         w = With(CamelCase())
-        # CamelCase doesn't change "foo" → "foo", falls through, base returns :foo
         @test Serde.ser_name(w, _WithFallthrough, Val(:foo)) == :foo
-        # Type-level override is independent
+        # Type-level override is independent of With
         @test Serde.ser_name(_WithFallthrough, Val(:foo)) == :FOO
     end
 


### PR DESCRIPTION
## Summary
- **`ser_name` / `deser_name` in `With`**: changed from first-wins to chain semantics — strategies now compose sequentially (e.g. `With(Prefix(), CamelCase())` applies both transformations in order)
- **`tag_key` / `tag_subtypes`**: added strategy-aware variants with context fallbacks, so tagged unions can be customized per-strategy instead of only globally
- **`With` rules for tags**: `tag_key` — first non-`nothing` wins; `tag_subtypes` — merge from all strategies

## Test plan
- [x] All 1078 existing tests pass
- [x] Updated `test_with.jl`: replaced first-wins naming test with chain composition test (`Prefix + CamelCase`)
- [x] Verified strategy-aware `tag_key` works end-to-end with `from_json`